### PR TITLE
Fix stoichiometric coefficient handling and add PNG graph export

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,10 @@ heats $\chi_f$ and $\chi_s$. The dimensionless species and energy equations
 mirror those of case02 but in scaled variables $\hat{x}$, $\hat{t}$, $\hat{c}_i$ and
 $\hat{T}_{f,s}$.
 
+## Utilities
+
+The scripts `chemkin_to_md.py` and `chemkin_to_graph.py` help document CHEMKIN
+reaction mechanisms. The former renders the `REACTIONS` block in a Markdown
+list, while the latter builds a Graphviz graph of species connectivity. PNG
+output from `chemkin_to_graph.py` requires the Graphviz `dot` executable.
+

--- a/chemkin_to_graph.py
+++ b/chemkin_to_graph.py
@@ -1,0 +1,87 @@
+import re
+import subprocess
+import sys
+from pathlib import Path
+import shutil
+
+
+def parse_reactions(text: str):
+    lines = text.splitlines()
+    edges = set()
+    in_section = False
+    for line in lines:
+        line = line.strip()
+        if not in_section:
+            if line.upper() == 'REACTIONS':
+                in_section = True
+            continue
+        if line.upper() == 'END':
+            break
+        if '=' not in line or line.startswith('!'):
+            continue
+        line_no_comment = line.split('!')[0].rstrip()
+        formula = re.split(r"\s{2,}", line_no_comment)[0].strip()
+        reversible = False
+        if '<=>' in formula or ('=' in formula and '=>' not in formula):
+            lhs, rhs = re.split(r'<=>|=', formula)
+            reversible = True
+        elif '=>' in formula:
+            lhs, rhs = formula.split('=>')
+        elif '->' in formula:
+            lhs, rhs = formula.split('->')
+        else:
+            continue
+        reactants = split_species(lhs)
+        products = split_species(rhs)
+        for r in reactants:
+            for p in products:
+                edges.add((r, p))
+                if reversible:
+                    edges.add((p, r))
+    return edges
+
+
+def split_species(side: str):
+    # remove third-body notation like (+M), (+N2)
+    side = re.sub(r'\(\+[^)]+\)', '', side)
+    species = []
+    for token in side.split('+'):
+        token = token.strip()
+        if not token:
+            continue
+        token = re.sub(r'^\d+', '', token).strip()
+        if not token or token == 'M':
+            continue
+        species.append(token)
+    return species
+
+
+def build_dot(edges) -> str:
+    lines = ['digraph G {']
+    for src, dst in sorted(edges):
+        lines.append(f'    "{src}" -> "{dst}";')
+    lines.append('}')
+    return '\n'.join(lines)
+
+
+def convert_file(inp: Path, out: Path):
+    content = inp.read_text()
+    edges = parse_reactions(content)
+    dot = build_dot(edges)
+    suffix = out.suffix.lower()
+    if suffix == '.dot':
+        out.write_text(dot)
+    elif suffix == '.png':
+        dot_cmd = shutil.which('dot')
+        if not dot_cmd:
+            raise RuntimeError('Graphviz "dot" executable not found; install graphviz to output PNG')
+        subprocess.run([dot_cmd, '-Tpng', '-o', str(out)], input=dot.encode(), check=True)
+    else:
+        raise ValueError('Output file must end with .dot or .png')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print('Usage: python chemkin_to_graph.py <chem.inp> <output.{dot,png}>')
+        sys.exit(1)
+    convert_file(Path(sys.argv[1]), Path(sys.argv[2]))

--- a/chemkin_to_md.py
+++ b/chemkin_to_md.py
@@ -1,0 +1,87 @@
+import re
+import sys
+from pathlib import Path
+
+
+def format_formula(formula: str) -> str:
+    """Convert a CHEMKIN reaction string to LaTeX-friendly form."""
+    # determine arrow type
+    if '<=>' in formula or ('=' in formula and '=>' not in formula):
+        arrow = '\\rightleftharpoons'
+        formula = formula.replace('<=>', ' -> ').replace('=', ' -> ')
+    elif '=>' in formula:
+        arrow = '\\rightarrow'
+        formula = formula.replace('=>', ' -> ')
+    else:
+        arrow = '\\rightarrow'
+
+    # insert spaces around + and parentheses
+    formula = formula.replace('+', ' + ')
+    formula = formula.replace('(', ' (')
+    formula = re.sub(r'\s+', ' ', formula).strip()
+    # tidy spaces inside third-body parentheses: '( + M)' -> '(+M)'
+    formula = re.sub(r'\( \+ ([^\)]+)\)', r'(+\1)', formula)
+    formula = formula.replace('->', arrow)
+    # replace digits that follow element symbols or ')' with subscripts,
+    # leaving leading stoichiometric coefficients untouched
+    formula = re.sub(r'(?<=[A-Za-z)])(\d+)', r'_{\1}', formula)
+    return formula
+
+
+def parse_reactions(text: str):
+    lines = text.splitlines()
+    reactions = []
+    in_section = False
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if not in_section:
+            if line.upper() == 'REACTIONS':
+                in_section = True
+            i += 1
+            continue
+        if line.upper() == 'END':
+            break
+        if '=' in line and not line.startswith('!'):
+            # grab the reaction formula before the rate coefficients.
+            # Coefficients are typically separated from the formula by two or
+            # more spaces, while single spaces may exist inside the formula.
+            line_no_comment = line.split('!')[0].rstrip()
+            formula = re.split(r'\s{2,}', line_no_comment)[0].strip()
+            dup = False
+            j = i + 1
+            while j < len(lines) and lines[j].strip() == '':
+                j += 1
+            if j < len(lines) and lines[j].strip().upper().startswith('DUP'):
+                dup = True
+                i = j  # skip the DUP line
+            formatted = format_formula(formula)
+            reactions.append((formatted, dup))
+        i += 1
+    return reactions
+
+
+def convert_file(path: Path) -> str:
+    content = path.read_text()
+    reactions = parse_reactions(content)
+    md_lines = []
+    md_lines.append('以下は、`{}` の **REACTIONS** セクションに記載された化学反応式を Markdown 形式で整理した一覧です\n'.format(path))
+    for idx, (formula, dup) in enumerate(reactions, start=1):
+        line = f"{idx}. $\\mathrm{{{formula}}}$"
+        if dup:
+            line += " *(DUP)*"
+        md_lines.append(line)
+    md_lines.append('')
+    return '\n'.join(md_lines)
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2 or len(sys.argv) > 3:
+        print('Usage: python chemkin_to_md.py <chem.inp> [output.md]')
+        sys.exit(1)
+    inp = Path(sys.argv[1])
+    md_text = convert_file(inp)
+    if len(sys.argv) == 3:
+        Path(sys.argv[2]).write_text(md_text)
+    else:
+        print(md_text)


### PR DESCRIPTION
## Summary
- ensure only elemental digits become subscripts so leading coefficients stay normal
- parse reaction formulas up to the first rate-coefficient field to handle spaced species
- allow chemkin_to_graph.py to output Graphviz networks directly as PNG images
- detect missing Graphviz `dot` and raise a clear error when PNG export is requested

## Testing
- `python scrap/chemkin_to_md.py scrap/case04/chem.inp >/tmp/output.md`
- `python scrap/chemkin_to_graph.py scrap/case04/chem.inp /tmp/graph.png`


------
https://chatgpt.com/codex/tasks/task_e_68a00860827c8322a70b08c495e35020