### PR TITLE
Templatize solver and add output interval

### DIFF
--- a/case04/main.cpp
+++ b/case04/main.cpp
@@ -9,10 +9,11 @@
 #include <cmath>
 #include <functional>
 
+template<typename T>
 struct Reaction {
-    std::vector<std::pair<int,double>> react;
-    std::vector<std::pair<int,double>> prod;
-    double A{}, b{}, E{};
+    std::vector<std::pair<int,T>> react;
+    std::vector<std::pair<int,T>> prod;
+    T A{}, b{}, E{};
 };
 
 static std::string trim(const std::string& s){
@@ -22,9 +23,10 @@ static std::string trim(const std::string& s){
     return s.substr(b, e-b+1);
 }
 
-static std::vector<std::pair<int,double>>
+template<typename T>
+static std::vector<std::pair<int,T>>
 parse_side(const std::string& side, const std::map<std::string,int>& idx){
-    std::vector<std::pair<int,double>> res;
+    std::vector<std::pair<int,T>> res;
     std::string token;
     for(size_t i=0;i<=side.size();++i){
         if(i==side.size() || side[i]=='+'){
@@ -35,10 +37,10 @@ parse_side(const std::string& side, const std::map<std::string,int>& idx){
                     token.clear();
                     continue;
                 }
-                double coeff = 1.0;
+                T coeff = static_cast<T>(1.0);
                 size_t j=0;
                 while(j<token.size() && (std::isdigit(token[j])||token[j]=='.')) j++;
-                if(j>0) coeff = std::stod(token.substr(0,j));
+                if(j>0) coeff = static_cast<T>(std::stod(token.substr(0,j)));
                 std::string name = token.substr(j);
                 auto it = idx.find(name);
                 if(it!=idx.end()) res.push_back({it->second, coeff});
@@ -50,10 +52,11 @@ parse_side(const std::string& side, const std::map<std::string,int>& idx){
     return res;
 }
 
+template<typename T>
 static bool load_chemkin(const std::string& fname,
                          std::vector<std::string>& species,
                          std::map<std::string,int>& idx,
-                         std::vector<Reaction>& reactions){
+                         std::vector<Reaction<T>>& reactions){
     std::ifstream ifs(fname);
     if(!ifs) return false;
     species.clear();
@@ -118,24 +121,27 @@ static bool load_chemkin(const std::string& fname,
                 lhs = expr.substr(0,pos);
                 rhs = expr.substr(pos+1);
             } else continue;
-            Reaction r;
-            r.react = parse_side(lhs, idx);
-            r.prod  = parse_side(rhs, idx);
-            r.A=A; r.b=b; r.E=E;
+            Reaction<T> r;
+            r.react = parse_side<T>(lhs, idx);
+            r.prod  = parse_side<T>(rhs, idx);
+            r.A = static_cast<T>(A);
+            r.b = static_cast<T>(b);
+            r.E = static_cast<T>(E);
             reactions.push_back(r);
         }
     }
     return true;
 }
 
-static void compute_rates(const std::vector<Reaction>& reactions, double T,
-                          const std::vector<double>& c, std::vector<double>& dc){
-    std::fill(dc.begin(), dc.end(), 0.0);
+template<typename T>
+static void compute_rates(const std::vector<Reaction<T>>& reactions, T Tgas,
+                          const std::vector<T>& c, std::vector<T>& dc){
+    std::fill(dc.begin(), dc.end(), T(0));
     for(const auto& r: reactions){
-        double k = r.A * std::pow(T, r.b) * std::exp(-r.E / T);
-        double rate = k;
+        T k = r.A * std::pow(Tgas, r.b) * std::exp(-r.E / Tgas);
+        T rate = k;
         for(auto [i,nu]: r.react)
-            rate *= std::pow(std::max(c[i],0.0), nu);
+            rate *= std::pow(std::max(c[i], T(0)), nu);
         for(auto [i,nu]: r.react)
             dc[i] -= nu*rate;
         for(auto [i,nu]: r.prod)
@@ -144,98 +150,200 @@ static void compute_rates(const std::vector<Reaction>& reactions, double T,
 }
 
 
-using Callback = std::function<void(double,const std::vector<double>&)>;
-using Integrator = void(*)(std::vector<double>&, double, double, double,
-                          const std::vector<Reaction>&, Callback);
+template<typename T>
+using Callback = std::function<void(T,const std::vector<T>&)>;
+template<typename T>
+using Integrator = void(*)(std::vector<T>&, T, T, T,
+                          const std::vector<Reaction<T>>&, Callback<T>);
 
-static void euler(std::vector<double>& y, double t0, double t1, double T,
-                  const std::vector<Reaction>& reactions, Callback cb){
-    double h = (t1 - t0) / 1000.0;
-    double t = t0;
-    std::vector<double> dy(y.size());
+template<typename T>
+static void euler(std::vector<T>& y, T t0, T t1, T Tgas,
+                  const std::vector<Reaction<T>>& reactions, Callback<T> cb){
+    T h = (t1 - t0) / T(1000);
+    T t = t0;
+    std::vector<T> dy(y.size());
     while(t < t1){
         if(t + h > t1) h = t1 - t;
-        compute_rates(reactions, T, y, dy);
+        compute_rates(reactions, Tgas, y, dy);
         for(size_t i=0;i<y.size();++i) y[i] += h*dy[i];
-        for(auto& v : y) if(v < 0) v = 0;
+        for(auto& v : y) if(v < T(0)) v = T(0);
         t += h;
         if(cb) cb(t, y);
     }
 }
 
-static void rk45(std::vector<double>& y, double t0, double t1, double T,
-                 const std::vector<Reaction>& reactions, Callback cb){
-    const double tol = 1e-8;
-    double h = (t1 - t0) / 1000.0;
-    double t = t0;
+template<typename T>
+static void rk45(std::vector<T>& y, T t0, T t1, T Tgas,
+                 const std::vector<Reaction<T>>& reactions, Callback<T> cb){
+    const T tol = T(1e-8);
+    T h = (t1 - t0) / T(1000);
+    T t = t0;
     size_t n = y.size();
-    std::vector<double> k1(n),k2(n),k3(n),k4(n),k5(n),k6(n),yt(n),y4(n),y5(n);
+    std::vector<T> k1(n),k2(n),k3(n),k4(n),k5(n),k6(n),yt(n),y4(n),y5(n);
     while(t < t1){
         if(t + h > t1) h = t1 - t;
-        compute_rates(reactions, T, y, k1);
-        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(1.0/5.0*k1[i]);
-        compute_rates(reactions, T, yt, k2);
-        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(3.0/40.0*k1[i] + 9.0/40.0*k2[i]);
-        compute_rates(reactions, T, yt, k3);
-        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(3.0/10.0*k1[i] - 9.0/10.0*k2[i] + 6.0/5.0*k3[i]);
-        compute_rates(reactions, T, yt, k4);
-        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(-11.0/54.0*k1[i] + 2.5*k2[i] - 70.0/27.0*k3[i] + 35.0/27.0*k4[i]);
-        compute_rates(reactions, T, yt, k5);
-        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(1631.0/55296.0*k1[i] + 175.0/512.0*k2[i] + 575.0/13824.0*k3[i] + 44275.0/110592.0*k4[i] + 253.0/4096.0*k5[i]);
-        compute_rates(reactions, T, yt, k6);
-        double err = 0.0;
+        compute_rates(reactions, Tgas, y, k1);
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(1.0/5.0)*k1[i]);
+        compute_rates(reactions, Tgas, yt, k2);
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(3.0/40.0)*k1[i] + T(9.0/40.0)*k2[i]);
+        compute_rates(reactions, Tgas, yt, k3);
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(3.0/10.0)*k1[i] - T(9.0/10.0)*k2[i] + T(6.0/5.0)*k3[i]);
+        compute_rates(reactions, Tgas, yt, k4);
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(-11.0/54.0)*k1[i] + T(2.5)*k2[i] - T(70.0/27.0)*k3[i] + T(35.0/27.0)*k4[i]);
+        compute_rates(reactions, Tgas, yt, k5);
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(1631.0/55296.0)*k1[i] + T(175.0/512.0)*k2[i] + T(575.0/13824.0)*k3[i] + T(44275.0/110592.0)*k4[i] + T(253.0/4096.0)*k5[i]);
+        compute_rates(reactions, Tgas, yt, k6);
+        T err = T(0);
         for(size_t i=0;i<n;++i){
-            y5[i] = y[i] + h*(37.0/378.0*k1[i] + 250.0/621.0*k3[i] + 125.0/594.0*k4[i] + 512.0/1771.0*k6[i]);
-            y4[i] = y[i] + h*(2825.0/27648.0*k1[i] + 18575.0/48384.0*k3[i] + 13525.0/55296.0*k4[i] + 277.0/14336.0*k5[i] + 0.25*k6[i]);
+            y5[i] = y[i] + h*(T(37.0/378.0)*k1[i] + T(250.0/621.0)*k3[i] + T(125.0/594.0)*k4[i] + T(512.0/1771.0)*k6[i]);
+            y4[i] = y[i] + h*(T(2825.0/27648.0)*k1[i] + T(18575.0/48384.0)*k3[i] + T(13525.0/55296.0)*k4[i] + T(277.0/14336.0)*k5[i] + T(0.25)*k6[i]);
             err = std::max(err, std::abs(y5[i]-y4[i]));
         }
         if(err <= tol){
             y = y5;
-            for(auto& v : y) if(v < 0) v = 0;
+            for(auto& v : y) if(v < T(0)) v = T(0);
             t += h;
             if(cb) cb(t, y);
         }
-        double scale = (err==0.0 ? 2.0 : 0.9*std::pow(tol/err, 0.2));
-        scale = std::min(5.0, std::max(0.2, scale));
+        T scale = (err==T(0) ? T(2) : T(0.9)*std::pow(tol/err, T(0.2)));
+        scale = std::min(T(5), std::max(T(0.2), scale));
+        h *= scale;
+    }
+}
+
+template<typename T>
+static void rk78(std::vector<T>& y, T t0, T t1, T Tgas,
+                 const std::vector<Reaction<T>>& reactions, Callback<T> cb){
+    const T tol = T(1e-8);
+    T h = (t1 - t0) / T(1000);
+    T t = t0;
+    size_t n = y.size();
+    std::vector<T> k1(n),k2(n),k3(n),k4(n),k5(n),k6(n),k7(n),k8(n),
+                   k9(n),k10(n),k11(n),k12(n),k13(n),yt(n),y8(n);
+    while(t < t1){
+        if(t + h > t1) h = t1 - t;
+
+        compute_rates(reactions, Tgas, y, k1);
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(2.0/27.0)*k1[i]);
+        compute_rates(reactions, Tgas, yt, k2);
+
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(1.0/36.0)*k1[i] + T(1.0/12.0)*k2[i]);
+        compute_rates(reactions, Tgas, yt, k3);
+
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(1.0/24.0)*k1[i] + T(1.0/8.0)*k3[i]);
+        compute_rates(reactions, Tgas, yt, k4);
+
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(5.0/12.0)*k1[i] - T(25.0/16.0)*k3[i] + T(25.0/16.0)*k4[i]);
+        compute_rates(reactions, Tgas, yt, k5);
+
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(1.0/20.0)*k1[i] + T(1.0/4.0)*k4[i] + T(1.0/5.0)*k5[i]);
+        compute_rates(reactions, Tgas, yt, k6);
+
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(-25.0/108.0)*k1[i] + T(125.0/108.0)*k4[i]
+                                               - T(65.0/27.0)*k5[i] + T(125.0/54.0)*k6[i]);
+        compute_rates(reactions, Tgas, yt, k7);
+
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(31.0/300.0)*k1[i] + T(61.0/225.0)*k5[i]
+                                               - T(2.0/9.0)*k6[i] + T(13.0/900.0)*k7[i]);
+        compute_rates(reactions, Tgas, yt, k8);
+
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(2)*k1[i] - T(53.0/6.0)*k4[i]
+                                               + T(704.0/45.0)*k5[i] - T(107.0/9.0)*k6[i]
+                                               + T(67.0/90.0)*k7[i] + T(3)*k8[i]);
+        compute_rates(reactions, Tgas, yt, k9);
+
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(-91.0/108.0)*k1[i] + T(23.0/108.0)*k4[i]
+                                               - T(976.0/135.0)*k5[i] + T(311.0/54.0)*k6[i]
+                                               - T(19.0/60.0)*k7[i] + T(17.0/6.0)*k8[i]
+                                               - T(1.0/12.0)*k9[i]);
+        compute_rates(reactions, Tgas, yt, k10);
+
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(2383.0/4100.0)*k1[i]
+                                               - T(341.0/164.0)*k4[i] + T(4496.0/1025.0)*k5[i]
+                                               - T(301.0/82.0)*k6[i] + T(2133.0/4100.0)*k7[i]
+                                               + T(45.0/82.0)*k8[i] + T(45.0/164.0)*k9[i]
+                                               + T(18.0/41.0)*k10[i]);
+        compute_rates(reactions, Tgas, yt, k11);
+
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(3.0/205.0)*k1[i] - T(6.0/41.0)*k6[i]
+                                               - T(3.0/205.0)*k7[i] - T(3.0/41.0)*k8[i]
+                                               + T(3.0/41.0)*k9[i] + T(6.0/41.0)*k10[i]);
+        compute_rates(reactions, Tgas, yt, k12);
+
+        for(size_t i=0;i<n;++i) yt[i] = y[i] + h*(T(-1777.0/4100.0)*k1[i]
+                                               - T(341.0/164.0)*k4[i] + T(4496.0/1025.0)*k5[i]
+                                               - T(289.0/82.0)*k6[i] + T(2193.0/4100.0)*k7[i]
+                                               + T(51.0/82.0)*k8[i] + T(33.0/164.0)*k9[i]
+                                               + T(12.0/41.0)*k10[i] + k12[i]);
+        compute_rates(reactions, Tgas, yt, k13);
+
+        T err = T(0);
+        for(size_t i=0;i<n;++i){
+            y8[i] = y[i] + h*(T(34.0/105.0)*k6[i] + T(9.0/35.0)*(k7[i]+k8[i])
+                               + T(9.0/280.0)*(k9[i]+k10[i])
+                               + T(41.0/840.0)*(k12[i]+k13[i]));
+            T e = h*(T(-41.0/840.0)*k1[i] + T(-41.0/840.0)*k11[i]
+                     + T(41.0/840.0)*k12[i] + T(41.0/840.0)*k13[i]);
+            err = std::max(err, std::abs(e));
+        }
+        if(err <= tol){
+            y = y8;
+            for(auto& v : y) if(v < T(0)) v = T(0);
+            t += h;
+            if(cb) cb(t, y);
+        }
+        T scale = (err==T(0) ? T(2) : T(0.9)*std::pow(tol/err, T(1.0/8.0)));
+        scale = std::min(T(5), std::max(T(0.2), scale));
         h *= scale;
     }
 }
 
 int main(int argc, char** argv){
+    using T = double;
     std::vector<std::string> species;
     std::map<std::string,int> idx;
-    std::vector<Reaction> reactions;
-    if(!load_chemkin("chem.inp", species, idx, reactions)){
+    std::vector<Reaction<T>> reactions;
+    if(!load_chemkin<T>("chem.inp", species, idx, reactions)){
         std::cerr << "chem.inp not found\n";
         return 1;
     }
 
-    const double T = 1000.0;
-    std::vector<double> c(species.size(),1e-8);
-    if(!species.empty()) c[0] = 1.0;
-    if(species.size() > 1) c[1] = 0.5;
+    const T Tgas = T(1000.0);
+    std::vector<T> c(species.size(), T(1e-8));
+    if(!species.empty()) c[0] = T(1.0);
+    if(species.size() > 1) c[1] = T(0.5);
 
-    Integrator integrator = rk45;
-    if(argc>1 && std::string(argv[1])=="euler")
-        integrator = euler;
+    Integrator<T> integrator = rk45<T>;
+    if(argc>1){
+        std::string method = argv[1];
+        if(method=="euler")
+            integrator = euler<T>;
+        else if(method=="rk78")
+            integrator = rk78<T>;
+    }
 
-    std::vector<double> times{0.0};
-    std::vector<std::vector<double>> history{c};
-    auto cb = [&](double t,const std::vector<double>& y){
-        times.push_back(t);
-        history.push_back(y);
+    std::vector<T> times{T(0)};
+    std::vector<std::vector<T>> history{c};
+    const T output_interval = T(1e-5);
+    T next_output = output_interval;
+    auto cb = [&](T t,const std::vector<T>& y){
+        while(t >= next_output){
+            times.push_back(next_output);
+            history.push_back(y);
+            next_output += output_interval;
+        }
     };
 
-    integrator(c, 0.0, 1e-3, T, reactions, cb);
+    integrator(c, T(0), T(1e-3), Tgas, reactions, cb);
 
     std::ofstream ofs("case04.dat");
     ofs << "time";
     for(const auto& s : species) ofs << ' ' << s;
     ofs << '\n';
     for(size_t k=0;k<times.size();++k){
-        double sum=0; for(double v: history[k]) sum+=v;
+        T sum=T(0); for(T v: history[k]) sum+=v;
         ofs << times[k];
-        for(double v: history[k]) ofs << ' ' << (sum>0? v/sum : 0.0);
+        for(T v: history[k]) ofs << ' ' << (sum>0? v/sum : T(0));
         ofs << '\n';
     }
 


### PR DESCRIPTION
## Summary
- generalize case04 solver to use a templated floating-point type with default `double`
- add an output interval so history samples are recorded at fixed time steps
- implement an adaptive Runge–Kutta 7/8 integrator for the `rk78` mode

## Testing
- `make -C case04`
- `cd case04 && ./chem`
- `cd case04 && ./chem rk78`


------
https://chatgpt.com/codex/tasks/task_e_68a014f9bb1c8322854b3e92d46c8ad5