### PR TITLE
Always solve energy equation in case04

### DIFF
--- a/case04/README.md
+++ b/case04/README.md
@@ -8,9 +8,8 @@ constant pressure of **202650 Pa**.  The program supports a classical
 fourth‑order method as well as adaptive Runge–Kutta–Fehlberg 4(5) and 7(8)
 integrators.
 
-The solver now also evaluates the **energy equation**, allowing the mixture
-temperature to evolve according to the reaction enthalpies provided in
-`therm.dat`.
+The solver evaluates the **energy equation**, allowing the mixture temperature
+to evolve according to reaction enthalpies provided in `therm.dat`.
 
 ### Initial conditions
 

--- a/case04/chem.hpp
+++ b/case04/chem.hpp
@@ -215,7 +215,8 @@ inline bool load_thermo(const std::string& fname,
 template<typename T>
 inline void compute_rhs(const std::vector<Reaction<T>>& reactions,
                         const std::vector<ThermoData<T>>& thermo,
-                        T P, const std::vector<T>& y, std::vector<T>& dy){
+                        T P, const std::vector<T>& y, std::vector<T>& dy,
+                        bool solve_energy = true){
     const T R = static_cast<T>(8.3144621);
     size_t n = y.size()-1;                 // last entry is temperature
     T Tval = y[n];
@@ -251,28 +252,32 @@ inline void compute_rhs(const std::vector<Reaction<T>>& reactions,
     for(size_t i=0;i<n;++i)
         if(y[i] <= T(0) && dy[i] < T(0)) dy[i] = T(0);
 
-    // Temperature equation using species enthalpies from thermo data
-    T sumY = T(0);
-    for(size_t i=0;i<n;++i) sumY += y[i];
-    T cp_mix = T(0);
-    T heat = T(0);
-    for(size_t i=0;i<n;++i){
-        const auto& td = thermo[i];
-        const T* c = (Tval >= td.t_mid) ? td.high : td.low;
-        T t = Tval;
-        T t2 = t*t;
-        T t3 = t2*t;
-        T t4 = t3*t;
-        // cp and enthalpy (J/mol/K and J/mol)
-        T cp_i = R*(c[0] + c[1]*t + c[2]*t2 + c[3]*t3 + c[4]*t4);
-        T h_i = R*t*(c[0] + c[1]*t/T(2) + c[2]*t2/T(3) +
-                     c[3]*t3/T(4) + c[4]*t4/T(5) + c[5]/t);
-        T Xi = (sumY>0)? y[i]/sumY : T(0);
-        cp_mix += Xi * cp_i;
-        heat += h_i * dy[i];
+    if(solve_energy){
+        // Temperature equation using species enthalpies from thermo data
+        T sumY = T(0);
+        for(size_t i=0;i<n;++i) sumY += y[i];
+        T cp_mix = T(0);
+        T heat = T(0);
+        for(size_t i=0;i<n;++i){
+            const auto& td = thermo[i];
+            const T* c = (Tval >= td.t_mid) ? td.high : td.low;
+            T t = Tval;
+            T t2 = t*t;
+            T t3 = t2*t;
+            T t4 = t3*t;
+            // cp and enthalpy (J/mol/K and J/mol)
+            T cp_i = R*(c[0] + c[1]*t + c[2]*t2 + c[3]*t3 + c[4]*t4);
+            T h_i = R*t*(c[0] + c[1]*t/T(2) + c[2]*t2/T(3) +
+                         c[3]*t3/T(4) + c[4]*t4/T(5) + c[5]/t);
+            T Xi = (sumY>0)? y[i]/sumY : T(0);
+            cp_mix += Xi * cp_i;
+            heat += h_i * dy[i];
+        }
+        T Ctot = P/(R*Tval); // total molar concentration
+        if(cp_mix <= T(0)) cp_mix = T(1); // prevent divide-by-zero
+        dy[n] = -heat / (Ctot * cp_mix);
+    } else {
+        dy[n] = T(0);
     }
-    T Ctot = P/(R*Tval); // total molar concentration
-    if(cp_mix <= T(0)) cp_mix = T(1); // prevent divide-by-zero
-    dy[n] = -heat / (Ctot * cp_mix);
 }
 

--- a/case04/integrators.hpp
+++ b/case04/integrators.hpp
@@ -19,7 +19,7 @@
 template<typename T>
 using Integrator = void(*)(std::vector<T>&, T, T, T,
                           T, T,
-                          const std::vector<Reaction<T>>&, const std::vector<ThermoData<T>>&);
+                          const std::vector<Reaction<T>>&, const std::vector<ThermoData<T>> &);
 
 // Classical fourth-order Runge–Kutta with a fixed number of steps.
 // The tolerance arguments are ignored; this routine is mainly used for

--- a/case04/main.cpp
+++ b/case04/main.cpp
@@ -67,7 +67,9 @@ int main(int argc, char** argv){
             else if(key=="TEMP") cfg >> T0;
             else if(key=="TIME") cfg >> t_end;
             else if(key=="DELT") cfg >> output_interval;
-            else{
+            else if(key=="ENERG" || key=="ENERGY"){
+                cfg.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            } else{
                 T val; cfg >> val; set_init(key, val);
             }
         }


### PR DESCRIPTION
## Summary
- Compute temperature derivative from species enthalpies and heat release
- Provide `solve_energy` switch defaulted to true so energy equation is integrated by default

## Testing
- `make -C case04 run`


------
https://chatgpt.com/codex/tasks/task_e_68a198a4d640832280d31269b59a318b