### PR TITLE
Allow tolerances configuration and plot thermodynamic data

### DIFF
--- a/case04/README.md
+++ b/case04/README.md
@@ -37,6 +37,8 @@ PRES 202650     # pressure in Pa
 TEMP 1000       # initial temperature in K
 TIME 1e-3       # end time
 DELT 1e-5       # output interval
+RTOL 1e-6       # relative tolerance for adaptive integrators
+ATOL 1e-12      # absolute tolerance
 H2   1.0        # species amounts
 O2   1.0
 N2   3.76
@@ -56,6 +58,9 @@ Running the example produces `case04.dat` containing time histories of mole
 fractions and temperature.  A bundled gnuplot script (`plot.gp`) is invoked
 automatically to create `case04.png`, visualizing mole fraction versus time for
 every species, and `case04_conc.png` showing molar concentration histories.
+Additionally, `plot_thermo.py` reads `therm.dat` and writes `cp.png`,
+`h.png` and `s.png`, plotting specific heat, enthalpy and entropy as functions
+of temperature for all species.
 
 ## Build and run
 

--- a/case04/input.start
+++ b/case04/input.start
@@ -7,6 +7,8 @@ TEMP 1000.0     # initial temperature [K]
 TIME 1e-3       # integration end time [s]
 DELT 1e-5       # output interval [s]
 #DT   1e-7      # optional step size override
+RTOL 1e-6       # relative tolerance
+ATOL 1e-12      # absolute tolerance
 
 # Initial species amounts (arbitrary moles) --------------------------------
 H2 1.0

--- a/case04/main.cpp
+++ b/case04/main.cpp
@@ -56,6 +56,8 @@ int main(int argc, char** argv){
     T t_end = T(1e-3);
     T output_interval = T(1e-5);
     T dt = output_interval / T(1000);   // Initial step size
+    T rtol = T(1e-6);                   // Relative tolerance
+    T atol = T(1e-12);                  // Absolute tolerance
 
     // Optional overrides from input.start -----------------------------------
     std::ifstream cfg("input.start");
@@ -69,6 +71,8 @@ int main(int argc, char** argv){
             else if(key=="TIME") cfg >> t_end;
             else if(key=="DELT") { cfg >> output_interval; dt = output_interval / T(1000); }
             else if(key=="DT")   cfg >> dt;
+            else if(key=="RTOL") cfg >> rtol;
+            else if(key=="ATOL") cfg >> atol;
             else if(key=="ENERG" || key=="ENERGY"){
                 cfg.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
             } else{
@@ -92,9 +96,6 @@ int main(int argc, char** argv){
         if(method == "rk45") integrator = rk45<T>;
         else if(method == "rk78") integrator = rk78<T>;
     }
-
-    const T rtol = T(1e-6);
-    const T atol = T(1e-12);
 
     // March solution in time ------------------------------------------------
     T t = T(0);

--- a/case04/makefile
+++ b/case04/makefile
@@ -11,6 +11,7 @@ $(TARGET): $(SOURCES)
 	$(CXX) $(CXXFLAGS) $(SOURCES) -o $@
 
 run: $(TARGET)
+	python plot_thermo.py
 	./$(TARGET) rk78
 	gnuplot plot.gp
 

--- a/case04/plot_thermo.py
+++ b/case04/plot_thermo.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Plot thermodynamic properties from NASA polynomial data in therm.dat.
+
+The script reads the thermodynamic coefficients, evaluates specific heat,
+enthalpy and entropy over the valid temperature range and writes three PNG
+files (`cp.png`, `h.png`, `s.png`).
+"""
+import math
+from pathlib import Path
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+R = 8.3144621  # J/mol/K
+
+def load_thermo(fname):
+    with open(fname) as f:
+        lines = [line.rstrip('\n') for line in f]
+    # locate header with temperature limits
+    i = 0
+    while i < len(lines):
+        if lines[i].strip().startswith('THERMO'):
+            i += 1
+            t_low, t_mid, t_high = map(float, lines[i].split()[:3])
+            i += 1
+            break
+        i += 1
+    data = {}
+    while i < len(lines):
+        line = lines[i]
+        if line.strip().startswith('END'):
+            break
+        name = line[:16].strip()
+        l2 = lines[i+1][:-2]
+        l3 = lines[i+2][:-2]
+        l4 = lines[i+3][:-2]
+        def parse(line):
+            fields = []
+            for j in range(0, len(line), 15):
+                chunk = line[j:j+15].strip()
+                if chunk:
+                    fields.append(float(chunk))
+            return fields
+        coeffs = parse(l2) + parse(l3) + parse(l4)
+        data[name] = {
+            't_mid': t_mid,
+            'high': coeffs[:7],
+            'low': coeffs[7:]
+        }
+        i += 4
+    return t_low, t_high, data
+
+def thermo_props(T, coeffs):
+    c = coeffs['high'] if T >= coeffs['t_mid'] else coeffs['low']
+    t = T
+    t2, t3, t4 = t*t, t*t*t, t*t*t*t
+    cp = R*(c[0] + c[1]*t + c[2]*t2 + c[3]*t3 + c[4]*t4)
+    h = R*t*(c[0] + c[1]*t/2 + c[2]*t2/3 + c[3]*t3/4 + c[4]*t4/5 + c[5]/t)
+    s = R*(c[0]*math.log(t) + c[1]*t + c[2]*t2/2 + c[3]*t3/3 + c[4]*t4/4 + c[6])
+    return cp, h, s
+
+def main():
+    base = Path(__file__).resolve().parent
+    t_low, t_high, thermo = load_thermo(base / 'therm.dat')
+    T = np.linspace(t_low, t_high, 400)
+    figs = {
+        'cp': plt.figure(),
+        'h': plt.figure(),
+        's': plt.figure(),
+    }
+    axes = {k: figs[k].gca() for k in figs}
+    for name, coeffs in thermo.items():
+        cp_vals = []
+        h_vals = []
+        s_vals = []
+        for temp in T:
+            cp_i, h_i, s_i = thermo_props(temp, coeffs)
+            cp_vals.append(cp_i)
+            h_vals.append(h_i)
+            s_vals.append(s_i)
+        axes['cp'].plot(T, cp_vals, label=name)
+        axes['h'].plot(T, h_vals, label=name)
+        axes['s'].plot(T, s_vals, label=name)
+    axes['cp'].set_xlabel('Temperature [K]')
+    axes['cp'].set_ylabel('cp [J/mol/K]')
+    axes['h'].set_xlabel('Temperature [K]')
+    axes['h'].set_ylabel('h [J/mol]')
+    axes['s'].set_xlabel('Temperature [K]')
+    axes['s'].set_ylabel('s [J/mol/K]')
+    for ax in axes.values():
+        ax.legend()
+        ax.grid(True)
+    figs['cp'].tight_layout()
+    figs['h'].tight_layout()
+    figs['s'].tight_layout()
+    figs['cp'].savefig(base / 'cp.png')
+    figs['h'].savefig(base / 'h.png')
+    figs['s'].savefig(base / 's.png')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Allow users to set integrator `RTOL` and `ATOL` via `input.start` and propagate these values into the solver.
- Document tolerance options and add a utility script to plot heat capacity, enthalpy and entropy from `therm.dat`.
- Run script automatically in `make run` and generate thermodynamic PNGs.

## Testing
- `make -C case04`
- `python case04/plot_thermo.py`
- `./case04/chem rk4`


------
https://chatgpt.com/codex/tasks/task_e_68a1e311e8448322ad7f50571691f6bd