### PR TITLE
Ensure case04 outputs numbers with 15-digit precision

### DIFF
--- a/case04/main.cpp
+++ b/case04/main.cpp
@@ -115,7 +115,9 @@ int main(int argc, char** argv){
     std::ofstream ofs("case04.dat");
     std::ofstream ofs_conc("case04_conc.dat");
     ofs.setf(std::ios::scientific);
+    ofs.precision(15);
     ofs_conc.setf(std::ios::scientific);
+    ofs_conc.precision(15);
     ofs << "time";
     ofs_conc << "time";
     for(const auto& s : species){
@@ -140,8 +142,10 @@ int main(int argc, char** argv){
         ofs_conc << '\n';
     }
 
+    std::cout.setf(std::ios::scientific);
+    std::cout.precision(15);
     for(size_t i=0;i<n;++i)
-        std::cout<<species[i]<<" "<<y[i]<<"\n";
+        std::cout << species[i] << " " << y[i] << "\n";
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- Set scientific output precision to 15 digits for case04 data files and console output.

## Testing
- `cd case04 && make clean && make`
- `./chem`


------
https://chatgpt.com/codex/tasks/task_e_68a1e433ea408322b4f9aedf14de834a