### PR TITLE
Fix case04 Makefile recipe prefix and add test target

### DIFF
--- a/case04/makefile
+++ b/case04/makefile
@@ -18,9 +18,12 @@ $(TEST_TARGET): $(TEST_SOURCES)
 >$(CXX) $(CXXFLAGS) $(TEST_SOURCES) -o $@
 
 run: $(TARGET)
-	python3 plot_thermo.py
-	./$(TARGET) rk78
-	gnuplot plot.gp
+>python3 plot_thermo.py
+>./$(TARGET) rk78
+>gnuplot plot.gp
+
+test: $(TEST_TARGET)
+>./$(TEST_TARGET)
 
 clean:
 >rm -f $(TARGET) $(TEST_TARGET)


### PR DESCRIPTION
## Summary
- fix run rule to use `>` recipe prefix
- add `test` target that runs `test_harmonic`

## Testing
- `make -C case04 test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ec022b448322808a33b30843a32b