### PR TITLE
Add literature references to advection schemes and simulation

### DIFF
--- a/convec/src/schemes/centered8.rs
+++ b/convec/src/schemes/centered8.rs
@@ -1,56 +1,87 @@
+//! 8次精度の中心差分による移流項の離散化を行うスキーム。
+//! 係数は Fornberg による有限差分公式の一般化\[1\]に基づく。
+//!
+//! [1] B. Fornberg, "Generation of finite difference formulas on arbitrarily spaced grids",
+//! *Mathematics of Computation*, 51(184), 699-706, 1988.
 use crate::schemes::Scheme;
 use crate::utils::{idx, pid};
 
 pub struct Centered8;
 
-const C8: [f64; 9] = [ 1.0/280.0, -4.0/105.0, 1.0/5.0, -4.0/5.0, 0.0,
-                       4.0/5.0,   -1.0/5.0,   4.0/105.0, -1.0/280.0 ];
+const C8: [f64; 9] = [
+    1.0 / 280.0,
+    -4.0 / 105.0,
+    1.0 / 5.0,
+    -4.0 / 5.0,
+    0.0,
+    4.0 / 5.0,
+    -1.0 / 5.0,
+    4.0 / 105.0,
+    -1.0 / 280.0,
+];
 
-fn d1x(f:&[f64], nx:usize, ny:usize, dx:f64, out:&mut [f64]){
+fn d1x(f: &[f64], nx: usize, ny: usize, dx: f64, out: &mut [f64]) {
     for j in 0..ny {
         for i in 0..nx {
             let mut acc = 0.0;
-            for s in -4..=4 { if s!=0 {
-                let w = C8[(s+4) as usize];
-                let ii = pid(i as isize + s as isize, nx);
-                acc += w * f[idx(ii,j,nx)];
-            }}
-            out[idx(i,j,nx)] = acc / dx;
+            for s in -4..=4 {
+                if s != 0 {
+                    let w = C8[(s + 4) as usize];
+                    let ii = pid(i as isize + s as isize, nx);
+                    acc += w * f[idx(ii, j, nx)];
+                }
+            }
+            out[idx(i, j, nx)] = acc / dx;
         }
     }
 }
-fn d1y(f:&[f64], nx:usize, ny:usize, dy:f64, out:&mut [f64]){
+fn d1y(f: &[f64], nx: usize, ny: usize, dy: f64, out: &mut [f64]) {
     for j in 0..ny {
         for i in 0..nx {
             let mut acc = 0.0;
-            for s in -4..=4 { if s!=0 {
-                let w = C8[(s+4) as usize];
-                let jj = pid(j as isize + s as isize, ny);
-                acc += w * f[idx(i,jj,nx)];
-            }}
-            out[idx(i,j,nx)] = acc / dy;
+            for s in -4..=4 {
+                if s != 0 {
+                    let w = C8[(s + 4) as usize];
+                    let jj = pid(j as isize + s as isize, ny);
+                    acc += w * f[idx(i, jj, nx)];
+                }
+            }
+            out[idx(i, j, nx)] = acc / dy;
         }
     }
 }
 
 impl Scheme for Centered8 {
-    fn rhs(&self, q:&[f64], u:&[f64], v:&[f64], dx:f64, dy:f64, nx:usize, ny:usize, out:&mut [f64]){
-        let mut dqx = vec![0.0; nx*ny];
-        let mut dqy = vec![0.0; nx*ny];
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
+        let mut dqx = vec![0.0; nx * ny];
+        let mut dqy = vec![0.0; nx * ny];
         d1x(q, nx, ny, dx, &mut dqx);
         d1y(q, nx, ny, dy, &mut dqy);
 
-        let mut uq = vec![0.0; nx*ny];
-        let mut vq = vec![0.0; nx*ny];
-        for k in 0..nx*ny { uq[k]=u[k]*q[k]; vq[k]=v[k]*q[k]; }
+        let mut uq = vec![0.0; nx * ny];
+        let mut vq = vec![0.0; nx * ny];
+        for k in 0..nx * ny {
+            uq[k] = u[k] * q[k];
+            vq[k] = v[k] * q[k];
+        }
 
-        let mut dx_uq = vec![0.0; nx*ny];
-        let mut dy_vq = vec![0.0; nx*ny];
+        let mut dx_uq = vec![0.0; nx * ny];
+        let mut dy_vq = vec![0.0; nx * ny];
         d1x(&uq, nx, ny, dx, &mut dx_uq);
         d1y(&vq, nx, ny, dy, &mut dy_vq);
 
-        for k in 0..nx*ny {
-            out[k] = -0.5 * ( u[k]*dqx[k] + dx_uq[k] + v[k]*dqy[k] + dy_vq[k] );
+        for k in 0..nx * ny {
+            out[k] = -0.5 * (u[k] * dqx[k] + dx_uq[k] + v[k] * dqy[k] + dy_vq[k]);
         }
     }
 }

--- a/convec/src/schemes/weno5.rs
+++ b/convec/src/schemes/weno5.rs
@@ -1,90 +1,126 @@
+//! 5次精度の加重基本的非振動 (WENO) スキームを用いた移流項評価。
+//! 実装は Jiang & Shu による古典的な WENO-JS スキーム\[1\]に基づいている。
+//!
+//! [1] G.-S. Jiang and C.-W. Shu, "Efficient implementation of Weighted ENO schemes",
+//! *Journal of Computational Physics*, 126(1), 202-228, 1996.
 use crate::schemes::Scheme;
 use crate::utils::{idx, pid};
 
 pub struct Weno5Js;
 
-fn weno5_fd_flux_faces_1d(f:&[f64], q:&[f64], alpha:f64) -> Vec<f64> {
+fn weno5_fd_flux_faces_1d(f: &[f64], q: &[f64], alpha: f64) -> Vec<f64> {
     let n = f.len();
     let eps = 1e-6;
     let mut fp = vec![0.0; n];
     let mut fm = vec![0.0; n];
-    for i in 0..n { fp[i]=0.5*(f[i]+alpha*q[i]); fm[i]=0.5*(f[i]-alpha*q[i]); }
+    for i in 0..n {
+        fp[i] = 0.5 * (f[i] + alpha * q[i]);
+        fm[i] = 0.5 * (f[i] - alpha * q[i]);
+    }
     let mut fh = vec![0.0; n];
     for i in 0..n {
         let im2 = fp[pid(i as isize - 2, n)];
         let im1 = fp[pid(i as isize - 1, n)];
-        let i0  = fp[i];
+        let i0 = fp[i];
         let ip1 = fp[pid(i as isize + 1, n)];
         let ip2 = fp[pid(i as isize + 2, n)];
-        let c0 = ( 2.0*im2 - 7.0*im1 + 11.0*i0 ) / 6.0;
-        let c1 = ( -im1 + 5.0*i0 + 2.0*ip1 ) / 6.0;
-        let c2 = ( 2.0*i0 + 5.0*ip1 - ip2 ) / 6.0;
-        let b0 = (13.0/12.0)*(im2 - 2.0*im1 + i0).powi(2) + 0.25*(im2 - 4.0*im1 + 3.0*i0).powi(2);
-        let b1 = (13.0/12.0)*(im1 - 2.0*i0 + ip1).powi(2) + 0.25*(im1 - ip1).powi(2);
-        let b2 = (13.0/12.0)*(i0  - 2.0*ip1 + ip2).powi(2) + 0.25*(3.0*i0 - 4.0*ip1 + ip2).powi(2);
-        let a0 = 0.1/(eps+b0).powi(2);
-        let a1 = 0.6/(eps+b1).powi(2);
-        let a2 = 0.3/(eps+b2).powi(2);
-        let s = a0+a1+a2;
-        let w0=a0/s; let w1=a1/s; let w2=a2/s;
-        let fph = w0*c0 + w1*c1 + w2*c2;
+        let c0 = (2.0 * im2 - 7.0 * im1 + 11.0 * i0) / 6.0;
+        let c1 = (-im1 + 5.0 * i0 + 2.0 * ip1) / 6.0;
+        let c2 = (2.0 * i0 + 5.0 * ip1 - ip2) / 6.0;
+        let b0 = (13.0 / 12.0) * (im2 - 2.0 * im1 + i0).powi(2)
+            + 0.25 * (im2 - 4.0 * im1 + 3.0 * i0).powi(2);
+        let b1 = (13.0 / 12.0) * (im1 - 2.0 * i0 + ip1).powi(2) + 0.25 * (im1 - ip1).powi(2);
+        let b2 = (13.0 / 12.0) * (i0 - 2.0 * ip1 + ip2).powi(2)
+            + 0.25 * (3.0 * i0 - 4.0 * ip1 + ip2).powi(2);
+        let a0 = 0.1 / (eps + b0).powi(2);
+        let a1 = 0.6 / (eps + b1).powi(2);
+        let a2 = 0.3 / (eps + b2).powi(2);
+        let s = a0 + a1 + a2;
+        let w0 = a0 / s;
+        let w1 = a1 / s;
+        let w2 = a2 / s;
+        let fph = w0 * c0 + w1 * c1 + w2 * c2;
 
         let im1m = fm[pid(i as isize - 1, n)];
-        let i0m  = fm[i];
+        let i0m = fm[i];
         let ip1m = fm[pid(i as isize + 1, n)];
         let ip2m = fm[pid(i as isize + 2, n)];
         let ip3m = fm[pid(i as isize + 3, n)];
-        let b0m = (13.0/12.0)*(i0m - 2.0*ip1m + ip2m).powi(2) + 0.25*(3.0*i0m - 4.0*ip1m + ip2m).powi(2);
-        let b1m = (13.0/12.0)*(im1m - 2.0*i0m + ip1m).powi(2) + 0.25*(im1m - ip1m).powi(2);
-        let b2m = (13.0/12.0)*(im1m - 2.0*ip1m + ip2m).powi(2) + 0.25*(im1m - 4.0*i0m + 3.0*ip1m).powi(2);
-        let a0m = 0.1/(eps+b0m).powi(2);
-        let a1m = 0.6/(eps+b1m).powi(2);
-        let a2m = 0.3/(eps+b2m).powi(2);
-        let sm = a0m+a1m+a2m;
-        let w0m=a0m/sm; let w1m=a1m/sm; let w2m=a2m/sm;
-        let cm0 = (-im1m + 5.0*i0m + 2.0*ip1m)/6.0;
-        let cm1 = ( 2.0*i0m + 5.0*ip1m - ip2m)/6.0;
-        let cm2 = (11.0*ip1m - 7.0*ip2m + 2.0*ip3m)/6.0;
-        let fmh = w2m*cm0 + w1m*cm1 + w0m*cm2;
+        let b0m = (13.0 / 12.0) * (i0m - 2.0 * ip1m + ip2m).powi(2)
+            + 0.25 * (3.0 * i0m - 4.0 * ip1m + ip2m).powi(2);
+        let b1m = (13.0 / 12.0) * (im1m - 2.0 * i0m + ip1m).powi(2) + 0.25 * (im1m - ip1m).powi(2);
+        let b2m = (13.0 / 12.0) * (im1m - 2.0 * ip1m + ip2m).powi(2)
+            + 0.25 * (im1m - 4.0 * i0m + 3.0 * ip1m).powi(2);
+        let a0m = 0.1 / (eps + b0m).powi(2);
+        let a1m = 0.6 / (eps + b1m).powi(2);
+        let a2m = 0.3 / (eps + b2m).powi(2);
+        let sm = a0m + a1m + a2m;
+        let w0m = a0m / sm;
+        let w1m = a1m / sm;
+        let w2m = a2m / sm;
+        let cm0 = (-im1m + 5.0 * i0m + 2.0 * ip1m) / 6.0;
+        let cm1 = (2.0 * i0m + 5.0 * ip1m - ip2m) / 6.0;
+        let cm2 = (11.0 * ip1m - 7.0 * ip2m + 2.0 * ip3m) / 6.0;
+        let fmh = w2m * cm0 + w1m * cm1 + w0m * cm2;
         fh[i] = fph + fmh;
     }
     fh
 }
 
 impl Scheme for Weno5Js {
-    fn rhs(&self, q:&[f64], u:&[f64], v:&[f64], dx:f64, dy:f64, nx:usize, ny:usize, out:&mut [f64]){
-        let mut dfx = vec![0.0; nx*ny];
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
+        let mut dfx = vec![0.0; nx * ny];
         for j in 0..ny {
             let mut f = vec![0.0; nx];
-            let mut qq= vec![0.0; nx];
-            let mut amax=0.0;
+            let mut qq = vec![0.0; nx];
+            let mut amax = 0.0;
             for i in 0..nx {
-                let k = idx(i,j,nx);
-                f[i]=u[k]*q[k]; qq[i]=q[k];
-                let a=u[k].abs(); if a>amax { amax=a; }
+                let k = idx(i, j, nx);
+                f[i] = u[k] * q[k];
+                qq[i] = q[k];
+                let a = u[k].abs();
+                if a > amax {
+                    amax = a;
+                }
             }
             let fh = weno5_fd_flux_faces_1d(&f, &qq, amax);
             for i in 0..nx {
                 let im = pid(i as isize - 1, nx);
-                dfx[idx(i,j,nx)] = (fh[i]-fh[im]) / dx;
+                dfx[idx(i, j, nx)] = (fh[i] - fh[im]) / dx;
             }
         }
-        let mut dfy = vec![0.0; nx*ny];
+        let mut dfy = vec![0.0; nx * ny];
         for i in 0..nx {
             let mut g = vec![0.0; ny];
-            let mut qq= vec![0.0; ny];
-            let mut amax=0.0;
+            let mut qq = vec![0.0; ny];
+            let mut amax = 0.0;
             for j in 0..ny {
-                let k = idx(i,j,nx);
-                g[j]=v[k]*q[k]; qq[j]=q[k];
-                let a=v[k].abs(); if a>amax { amax=a; }
+                let k = idx(i, j, nx);
+                g[j] = v[k] * q[k];
+                qq[j] = q[k];
+                let a = v[k].abs();
+                if a > amax {
+                    amax = a;
+                }
             }
             let gh = weno5_fd_flux_faces_1d(&g, &qq, amax);
             for j in 0..ny {
                 let jm = pid(j as isize - 1, ny);
-                dfy[idx(i,j,nx)] = (gh[j]-gh[jm]) / dy;
+                dfy[idx(i, j, nx)] = (gh[j] - gh[jm]) / dy;
             }
         }
-        for k in 0..nx*ny { out[k] = -(dfx[k] + dfy[k]); }
+        for k in 0..nx * ny {
+            out[k] = -(dfx[k] + dfy[k]);
+        }
     }
 }

--- a/convec/src/shapes.rs
+++ b/convec/src/shapes.rs
@@ -1,30 +1,50 @@
 use crate::config::InitialConditionCfg;
-use crate::utils::{idx};
+use crate::utils::idx;
 
+/// 初期条件を生成する。
+///
+/// Zalesak のスロット付き円柱テスト\[1\]は，移流スキームの形状保存性を評価する
+/// 代表的なベンチマークとして広く利用されている。
+/// 本関数ではその形状を含むいくつかの初期条件を生成する。
+///
+/// [1] S. T. Zalesak, "Fully multidimensional flux-corrected transport algorithms for fluids",
+/// *Journal of Computational Physics*, 31(3), 335-362, 1979.
 pub fn init_field(cfg: &InitialConditionCfg, nx: usize, ny: usize, lx: f64, ly: f64) -> Vec<f64> {
     let dx = lx / nx as f64;
     let dy = ly / ny as f64;
-    let mut q = vec![0.0; nx*ny];
+    let mut q = vec![0.0; nx * ny];
     match cfg {
-        InitialConditionCfg::Zalesak{center_x, center_y, radius, slot_width, slot_length} => {
+        InitialConditionCfg::Zalesak {
+            center_x,
+            center_y,
+            radius,
+            slot_width,
+            slot_length,
+        } => {
             for j in 0..ny {
-                let y = (j as f64 + 0.5)*dy;
+                let y = (j as f64 + 0.5) * dy;
                 for i in 0..nx {
-                    let x = (i as f64 + 0.5)*dx;
-                    let r2 = (x-center_x)*(x-center_x) + (y-center_y)*(y-center_y);
-                    let disk = r2 <= radius*radius;
-                    let slot = ( (x-center_x).abs() <= slot_width*0.5 ) && (y < center_y + radius) && (y > center_y + radius - slot_length);
-                    q[idx(i,j,nx)] = if disk && !slot { 1.0 } else { 0.0 };
+                    let x = (i as f64 + 0.5) * dx;
+                    let r2 = (x - center_x) * (x - center_x) + (y - center_y) * (y - center_y);
+                    let disk = r2 <= radius * radius;
+                    let slot = ((x - center_x).abs() <= slot_width * 0.5)
+                        && (y < center_y + radius)
+                        && (y > center_y + radius - slot_length);
+                    q[idx(i, j, nx)] = if disk && !slot { 1.0 } else { 0.0 };
                 }
             }
         }
-        InitialConditionCfg::Disk{center_x, center_y, radius} => {
+        InitialConditionCfg::Disk {
+            center_x,
+            center_y,
+            radius,
+        } => {
             for j in 0..ny {
-                let y = (j as f64 + 0.5)*dy;
+                let y = (j as f64 + 0.5) * dy;
                 for i in 0..nx {
-                    let x = (i as f64 + 0.5)*dx;
-                    let r2 = (x-center_x)*(x-center_x) + (y-center_y)*(y-center_y);
-                    q[idx(i,j,nx)] = if r2 <= radius*radius { 1.0 } else { 0.0 };
+                    let x = (i as f64 + 0.5) * dx;
+                    let r2 = (x - center_x) * (x - center_x) + (y - center_y) * (y - center_y);
+                    q[idx(i, j, nx)] = if r2 <= radius * radius { 1.0 } else { 0.0 };
                 }
             }
         }

--- a/convec/src/sim.rs
+++ b/convec/src/sim.rs
@@ -1,10 +1,15 @@
-use anyhow::Result;
 use crate::config::{Config, SchemeType, VelocityCfg};
 use crate::render::FrameWriter;
-use crate::schemes::{Scheme, Centered8, Weno5Js};
+use crate::schemes::{Centered8, Scheme, Weno5Js};
 use crate::shapes::init_field;
-use crate::utils::{idx};
+use crate::utils::idx;
+use anyhow::Result;
 
+/// 2 次元スカラー移流方程式を解くメインループ。
+/// 時間積分には Shu & Osher による 3 段の TVD Runge–Kutta 法\[1\]を用いる。
+///
+/// [1] C.-W. Shu and S. Osher, "Efficient implementation of essentially non-oscillatory
+/// shock-capturing schemes, II", *Journal of Computational Physics*, 83(1), 32-78, 1989.
 pub fn run(cfg: Config) -> Result<()> {
     let nx = cfg.simulation.nx;
     let ny = cfg.simulation.ny;
@@ -15,18 +20,26 @@ pub fn run(cfg: Config) -> Result<()> {
 
     let mut x = vec![0.0; nx];
     let mut y = vec![0.0; ny];
-    for i in 0..nx { x[i] = (i as f64 + 0.5)*dx; }
-    for j in 0..ny { y[j] = (j as f64 + 0.5)*dy; }
+    for i in 0..nx {
+        x[i] = (i as f64 + 0.5) * dx;
+    }
+    for j in 0..ny {
+        y[j] = (j as f64 + 0.5) * dy;
+    }
 
-    let mut u = vec![0.0; nx*ny];
-    let mut v = vec![0.0; nx*ny];
+    let mut u = vec![0.0; nx * ny];
+    let mut v = vec![0.0; nx * ny];
     match cfg.simulation.velocity {
-        VelocityCfg::SolidRotation{omega, center_x, center_y} => {
+        VelocityCfg::SolidRotation {
+            omega,
+            center_x,
+            center_y,
+        } => {
             for j in 0..ny {
                 for i in 0..nx {
-                    let k = idx(i,j,nx);
+                    let k = idx(i, j, nx);
                     u[k] = -omega * (y[j] - center_y);
-                    v[k] =  omega * (x[i] - center_x);
+                    v[k] = omega * (x[i] - center_x);
                 }
             }
         }
@@ -36,9 +49,11 @@ pub fn run(cfg: Config) -> Result<()> {
     let q0 = q.clone();
 
     let mut umax = 0.0;
-    for k in 0..nx*ny {
-        let s = (u[k]*u[k] + v[k]*v[k]).sqrt();
-        if s>umax { umax = s; }
+    for k in 0..nx * ny {
+        let s = (u[k] * u[k] + v[k] * v[k]).sqrt();
+        if s > umax {
+            umax = s;
+        }
     }
     let mut dt = cfg.simulation.cfl * dx.min(dy) / (umax + 1e-15);
     let t_end = cfg.simulation.rotations as f64;
@@ -48,44 +63,61 @@ pub fn run(cfg: Config) -> Result<()> {
 
     let scheme_box: Box<dyn Scheme> = match cfg.scheme.r#type {
         SchemeType::Centered8 => Box::new(Centered8),
-        SchemeType::Weno5     => Box::new(Weno5Js),
+        SchemeType::Weno5 => Box::new(Weno5Js),
     };
 
     let mut writer = FrameWriter::new(cfg.output.clone(), nx, ny)?;
-    if writer.cfg.enable { writer.write_frame(&q, 0)?; }
+    if writer.cfg.enable {
+        writer.write_frame(&q, 0)?;
+    }
 
-    let mut rhs = vec![0.0; nx*ny];
-    let mut q1  = vec![0.0; nx*ny];
-    let mut q2  = vec![0.0; nx*ny];
+    let mut rhs = vec![0.0; nx * ny];
+    let mut q1 = vec![0.0; nx * ny];
+    let mut q2 = vec![0.0; nx * ny];
 
     for n in 1..=steps {
         scheme_box.rhs(&q, &u, &v, dx, dy, nx, ny, &mut rhs);
-        for k in 0..nx*ny { q1[k] = q[k] + dt*rhs[k]; }
+        for k in 0..nx * ny {
+            q1[k] = q[k] + dt * rhs[k];
+        }
 
         scheme_box.rhs(&q1, &u, &v, dx, dy, nx, ny, &mut rhs);
-        for k in 0..nx*ny { q2[k] = 0.75*q[k] + 0.25*(q1[k] + dt*rhs[k]); }
+        for k in 0..nx * ny {
+            q2[k] = 0.75 * q[k] + 0.25 * (q1[k] + dt * rhs[k]);
+        }
 
         scheme_box.rhs(&q2, &u, &v, dx, dy, nx, ny, &mut rhs);
-        for k in 0..nx*ny { q[k] = (1.0/3.0)*q[k] + (2.0/3.0)*(q2[k] + dt*rhs[k]); }
+        for k in 0..nx * ny {
+            q[k] = (1.0 / 3.0) * q[k] + (2.0 / 3.0) * (q2[k] + dt * rhs[k]);
+        }
 
         writer.maybe_write(&q, n)?;
     }
 
-    let cell = dx*dy;
-    let mut qmin = q[0]; let mut qmax = q[0];
-    let mut m0=0.0; let mut m1=0.0; let mut l2=0.0;
+    let cell = dx * dy;
+    let mut qmin = q[0];
+    let mut qmax = q[0];
+    let mut m0 = 0.0;
+    let mut m1 = 0.0;
+    let mut l2 = 0.0;
     for j in 0..ny {
         for i in 0..nx {
-            let k = idx(i,j,nx);
-            m0 += q0[k]*cell; m1 += q[k]*cell;
-            if q[k]<qmin { qmin=q[k]; }
-            if q[k]>qmax { qmax=q[k]; }
-            let d = q[k]-q0[k]; l2 += d*d*cell;
+            let k = idx(i, j, nx);
+            m0 += q0[k] * cell;
+            m1 += q[k] * cell;
+            if q[k] < qmin {
+                qmin = q[k];
+            }
+            if q[k] > qmax {
+                qmax = q[k];
+            }
+            let d = q[k] - q0[k];
+            l2 += d * d * cell;
         }
     }
     println!("# results");
     println!("min={:.6e} max={:.6e}", qmin, qmax);
-    println!("mass0={:.6e} mass1={:.6e} mass_err={:.6e}", m0, m1, m1-m0);
+    println!("mass0={:.6e} mass1={:.6e} mass_err={:.6e}", m0, m1, m1 - m0);
     println!("L2 = {:.6e}", l2.sqrt());
     Ok(())
 }


### PR DESCRIPTION
## Summary
- document Zalesak slotted-disk initial condition with citation to original paper
- annotate centered 8th-order and WENO5 advection schemes with literature references
- describe TVD Runge–Kutta time stepping method

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ab04c2c01883228d476810e06ebecd