### PR TITLE
Improve convec visualization and document schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ heats $\chi_f$ and $\chi_s$. The dimensionless species and energy equations
 mirror those of case02 but in scaled variables $\hat{x}$, $\hat{t}$, $\hat{c}_i$ and
 $\hat{T}_{f,s}$.
 
+## convec: 2‑D scalar advection
+
+`convec` tracks the rotation of Zalesak's disk under a prescribed velocity
+field. Spatial derivatives use either an eighth‑order centred scheme or the
+fifth‑order WENO method, while time marching employs a three‑stage TVD
+Runge–Kutta integrator. The program writes PNG frames with the current time,
+colour bar and labelled axes for later animation. Further details and build
+instructions live in `convec/README.md`.
+
 ## case05: Pythagorean three-body problem
 
 `case05` integrates Burrau's Pythagorean three-body problem using GCC's

--- a/convec/README.md
+++ b/convec/README.md
@@ -1,5 +1,39 @@
 # Zalesak DNC (Rust + YAML)
 
+This program solves the two-dimensional passive scalar advection equation
+
+```math
+\frac{\partial q}{\partial t} + u\frac{\partial q}{\partial x} + v\frac{\partial q}{\partial y} = 0
+```
+
+with a solid body rotation velocity field. Two finite-difference schemes are
+available:
+
+* **Centered8** – eighth-order central derivative
+
+  ```math
+  \frac{\partial f}{\partial x}\Big|_i \approx \frac{1}{280\Delta x}(-3 f_{i-4}+32 f_{i-3}-168 f_{i-2}+672 f_{i-1}-672 f_{i+1}+168 f_{i+2}-32 f_{i+3}+3 f_{i+4})
+  ```
+
+* **WENO5** – fifth-order weighted essentially non-oscillatory scheme
+
+  ```math
+  \omega_k = \frac{\alpha_k}{\sum_{m=0}^2 \alpha_m},\qquad \alpha_k = \frac{d_k}{(\varepsilon+\beta_k)^2}
+  ```
+
+Time integration uses the third-order TVD Runge–Kutta method of Shu and Osher:
+
+```math
+\begin{aligned}
+q^{(1)} &= q^n + \Delta t\,L(q^n),\\
+q^{(2)} &= \tfrac{3}{4} q^n + \tfrac{1}{4}\big(q^{(1)} + \Delta t\,L(q^{(1)})\big),\\
+q^{n+1} &= \tfrac{1}{3} q^n + \tfrac{2}{3}\big(q^{(2)} + \Delta t\,L(q^{(2)})\big).
+\end{aligned}
+```
+
+Frames are saved with a colour bar, thicker axes, and the current simulation
+time overlaid in the corner for easier inspection.
+
 ## Build & Run
 ```bash
 cargo run --release -- --config config.yaml

--- a/convec/config.yaml
+++ b/convec/config.yaml
@@ -39,7 +39,7 @@ output:
   interp: bilinear
   grid: true
   grid_step: 8
-  grid_thick: 1
+  grid_thick: 2
   axes: true
   colormap: turbo
   colorbar: true

--- a/convec/src/render.rs
+++ b/convec/src/render.rs
@@ -1,6 +1,6 @@
-use crate::config::{OutputCfg, ScaleCfg, OutFmt, Interp, Colormap};
+use crate::config::{Colormap, Interp, OutFmt, OutputCfg, ScaleCfg};
 use crate::utils::{idx, pid};
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use image::{ImageBuffer, Rgb};
 use std::fs;
 use std::io::{self, Write};
@@ -8,7 +8,8 @@ use std::path::PathBuf;
 
 pub struct FrameWriter {
     pub cfg: OutputCfg,
-    nx: usize, ny: usize,
+    nx: usize,
+    ny: usize,
     next_id: usize,
 }
 
@@ -17,16 +18,29 @@ impl FrameWriter {
         if cfg.enable {
             fs::create_dir_all(&cfg.dir).with_context(|| format!("cannot create {}", cfg.dir))?;
         }
-        if cfg.out_w.is_none() { cfg.out_w = Some(nx); }
-        if cfg.out_h.is_none() { cfg.out_h = Some(ny); }
-        Ok(Self{ cfg, nx, ny, next_id: 0 })
+        if cfg.out_w.is_none() {
+            cfg.out_w = Some(nx);
+        }
+        if cfg.out_h.is_none() {
+            cfg.out_h = Some(ny);
+        }
+        Ok(Self {
+            cfg,
+            nx,
+            ny,
+            next_id: 0,
+        })
     }
-    pub fn maybe_write(&mut self, q: &Vec<f64>, step: usize) -> Result<()> {
-        if !self.cfg.enable { return Ok(()); }
-        if step % self.cfg.stride == 0 { self.write_frame(q, step)?; }
+    pub fn maybe_write(&mut self, q: &Vec<f64>, step: usize, time: f64) -> Result<()> {
+        if !self.cfg.enable {
+            return Ok(());
+        }
+        if step % self.cfg.stride == 0 {
+            self.write_frame(q, time)?;
+        }
         Ok(())
     }
-    pub fn write_frame(&mut self, q: &Vec<f64>, _step: usize) -> Result<()> {
+    pub fn write_frame(&mut self, q: &Vec<f64>, time: f64) -> Result<()> {
         let id = self.cfg.start_index + self.next_id;
         let fname = format!("{}_{:06}", self.cfg.prefix, id);
         let path = PathBuf::from(&self.cfg.dir).join(match self.cfg.format {
@@ -35,17 +49,29 @@ impl FrameWriter {
         });
 
         let (vmin, vmax) = match self.cfg.scale {
-            ScaleCfg::Fixed{min,max} => (min,max),
+            ScaleCfg::Fixed { min, max } => (min, max),
             ScaleCfg::Auto => {
-                let mut mn = q[0]; let mut mx = q[0];
-                for &v in q.iter() { if v<mn {mn=v}; if v>mx {mx=v}; }
-                if (mx-mn).abs() < 1e-14 { (mn-0.5, mx+0.5) } else { (mn, mx) }
+                let mut mn = q[0];
+                let mut mx = q[0];
+                for &v in q.iter() {
+                    if v < mn {
+                        mn = v
+                    };
+                    if v > mx {
+                        mx = v
+                    };
+                }
+                if (mx - mn).abs() < 1e-14 {
+                    (mn - 0.5, mx + 0.5)
+                } else {
+                    (mn, mx)
+                }
             }
         };
 
         let w = self.cfg.out_w.unwrap();
         let h = self.cfg.out_h.unwrap();
-        let mut buf: Vec<u8> = vec![0; w*h*3];
+        let mut buf: Vec<u8> = vec![0; w * h * 3];
 
         for py in 0..h {
             let gy = (py as f64 + 0.5) * (self.ny as f64) / (h as f64);
@@ -57,42 +83,64 @@ impl FrameWriter {
                     Interp::Nearest => {
                         let ii = pid(gx.round() as isize, self.nx);
                         let jj = pid(gy.round() as isize, self.ny);
-                        q[idx(ii,jj,self.nx)]
+                        q[idx(ii, jj, self.nx)]
                     }
                     Interp::Bilinear => {
-                        let i0u = pid(i0, self.nx); let i1u = pid(i0+1, self.nx);
-                        let j0u = pid(j0, self.ny); let j1u = pid(j0+1, self.ny);
-                        let q00 = q[idx(i0u,j0u,self.nx)];
-                        let q10 = q[idx(i1u,j0u,self.nx)];
-                        let q01 = q[idx(i0u,j1u,self.nx)];
-                        let q11 = q[idx(i1u,j1u,self.nx)];
-                        (1.0-tj)*((1.0-ti)*q00 + ti*q10) + tj*((1.0-ti)*q01 + ti*q11)
+                        let i0u = pid(i0, self.nx);
+                        let i1u = pid(i0 + 1, self.nx);
+                        let j0u = pid(j0, self.ny);
+                        let j1u = pid(j0 + 1, self.ny);
+                        let q00 = q[idx(i0u, j0u, self.nx)];
+                        let q10 = q[idx(i1u, j0u, self.nx)];
+                        let q01 = q[idx(i0u, j1u, self.nx)];
+                        let q11 = q[idx(i1u, j1u, self.nx)];
+                        (1.0 - tj) * ((1.0 - ti) * q00 + ti * q10)
+                            + tj * ((1.0 - ti) * q01 + ti * q11)
                     }
                 };
-                let norm = ((val - vmin) / (vmax - vmin)).clamp(0.0,1.0);
-                let (r,g,b) = match self.cfg.colormap {
-                    Colormap::Gray  => { let c=(255.0*norm) as u8; (c,c,c) }
+                let norm = ((val - vmin) / (vmax - vmin)).clamp(0.0, 1.0);
+                let (r, g, b) = match self.cfg.colormap {
+                    Colormap::Gray => {
+                        let c = (255.0 * norm) as u8;
+                        (c, c, c)
+                    }
                     Colormap::Turbo => turbo_rgb(norm),
                 };
-                let yy = if self.cfg.flip_y { h-1-py } else { py };
-                let p = (yy*w + px)*3;
-                buf[p]=r; buf[p+1]=g; buf[p+2]=b;
+                let yy = if self.cfg.flip_y { h - 1 - py } else { py };
+                let p = (yy * w + px) * 3;
+                buf[p] = r;
+                buf[p + 1] = g;
+                buf[p + 2] = b;
             }
         }
-        if self.cfg.grid && self.cfg.grid_step>0 {
-            draw_grid(&mut buf, w, h, self.nx, self.ny, self.cfg.grid_step, self.cfg.grid_thick, [255,255,255]);
+        if self.cfg.grid && self.cfg.grid_step > 0 {
+            draw_grid(
+                &mut buf,
+                w,
+                h,
+                self.nx,
+                self.ny,
+                self.cfg.grid_step,
+                self.cfg.grid_thick,
+                [200, 200, 200],
+            );
         }
         if self.cfg.axes {
-            draw_rect(&mut buf, w, h, 0,0,w-1,h-1, 2, [0,0,0]);
+            draw_rect(&mut buf, w, h, 0, 0, w - 1, h - 1, 3, [0, 0, 0]);
         }
+        // overlay current time in seconds at top-left
+        let label = format!("t = {:.2}", time);
+        draw_time_label(&mut buf, w, h, &label);
         if self.cfg.colorbar {
             draw_colorbar(&mut buf, w, h, self.cfg.colormap);
         }
 
         match self.cfg.format {
             OutFmt::Png => {
-                let img: ImageBuffer<Rgb<u8>, _> = ImageBuffer::from_raw(w as u32, h as u32, buf).unwrap();
-                img.save(&path).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                let img: ImageBuffer<Rgb<u8>, _> =
+                    ImageBuffer::from_raw(w as u32, h as u32, buf).unwrap();
+                img.save(&path)
+                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
             }
             OutFmt::Ppm => {
                 let mut file = fs::File::create(&path)?;
@@ -105,22 +153,47 @@ impl FrameWriter {
     }
 }
 
-fn draw_rect(buf:&mut [u8], w:usize, h:usize, x0:usize,y0:usize,x1:usize,y1:usize, thick:usize, color:[u8;3]){
+fn draw_rect(
+    buf: &mut [u8],
+    w: usize,
+    h: usize,
+    x0: usize,
+    y0: usize,
+    x1: usize,
+    y1: usize,
+    thick: usize,
+    color: [u8; 3],
+) {
     for t in 0..thick {
-        for x in x0..=x1 { set_px(buf,w,h, x, y0.saturating_add(t).min(h-1), color);
-                           set_px(buf,w,h, x, y1.saturating_sub(t), color); }
-        for y in y0..=y1 { set_px(buf,w,h, x0.saturating_add(t).min(w-1), y, color);
-                           set_px(buf,w,h, x1.saturating_sub(t), y, color); }
+        for x in x0..=x1 {
+            set_px(buf, w, h, x, y0.saturating_add(t).min(h - 1), color);
+            set_px(buf, w, h, x, y1.saturating_sub(t), color);
+        }
+        for y in y0..=y1 {
+            set_px(buf, w, h, x0.saturating_add(t).min(w - 1), y, color);
+            set_px(buf, w, h, x1.saturating_sub(t), y, color);
+        }
     }
 }
-fn draw_grid(buf:&mut [u8], w:usize, h:usize, nx:usize, ny:usize, step:usize, thick:usize, color:[u8;3]){
+fn draw_grid(
+    buf: &mut [u8],
+    w: usize,
+    h: usize,
+    nx: usize,
+    ny: usize,
+    step: usize,
+    thick: usize,
+    color: [u8; 3],
+) {
     // 垂直線
     for k in (0..=nx).step_by(step) {
         let mut xpix = ((k as f64) * (w as f64) / (nx as f64)).round() as usize;
-        if xpix >= w { xpix = w - 1; }
+        if xpix >= w {
+            xpix = w - 1;
+        }
         for y in 0..h {
             for t in 0..thick {
-                let x = xpix.saturating_add(t).min(w-1);
+                let x = xpix.saturating_add(t).min(w - 1);
                 set_px(buf, w, h, x, y, color);
             }
         }
@@ -128,39 +201,164 @@ fn draw_grid(buf:&mut [u8], w:usize, h:usize, nx:usize, ny:usize, step:usize, th
     // 水平線
     for k in (0..=ny).step_by(step) {
         let mut ypix = ((k as f64) * (h as f64) / (ny as f64)).round() as usize;
-        if ypix >= h { ypix = h - 1; }
+        if ypix >= h {
+            ypix = h - 1;
+        }
         for x in 0..w {
             for t in 0..thick {
-                let y = ypix.saturating_add(t).min(h-1);
+                let y = ypix.saturating_add(t).min(h - 1);
                 set_px(buf, w, h, x, y, color);
             }
         }
     }
 }
-#[inline] fn set_px(buf:&mut [u8], w:usize, h:usize, x:usize, y:usize, c:[u8;3]){
-    if x<w && y<h {
-        let p=(y*w+x)*3; buf[p]=c[0]; buf[p+1]=c[1]; buf[p+2]=c[2];
+#[inline]
+fn set_px(buf: &mut [u8], w: usize, h: usize, x: usize, y: usize, c: [u8; 3]) {
+    if x < w && y < h {
+        let p = (y * w + x) * 3;
+        buf[p] = c[0];
+        buf[p + 1] = c[1];
+        buf[p + 2] = c[2];
     }
 }
-fn draw_colorbar(buf:&mut [u8], w:usize, h:usize, cmap: Colormap){
+fn draw_colorbar(buf: &mut [u8], w: usize, h: usize, cmap: Colormap) {
     let cbw = (w as f64 * 0.05).round() as usize;
     let x0 = w.saturating_sub(cbw);
     for y in 0..h {
         let t = 1.0 - (y as f64 + 0.5) / (h as f64);
-        let (r,g,b) = match cmap {
-            Colormap::Gray  => { let c=(255.0*t) as u8; (c,c,c) }
+        let (r, g, b) = match cmap {
+            Colormap::Gray => {
+                let c = (255.0 * t) as u8;
+                (c, c, c)
+            }
             Colormap::Turbo => turbo_rgb(t),
         };
         for x in x0..w {
-            let p=(y*w+x)*3; buf[p]=r; buf[p+1]=g; buf[p+2]=b;
+            let p = (y * w + x) * 3;
+            buf[p] = r;
+            buf[p + 1] = g;
+            buf[p + 2] = b;
         }
     }
 }
-fn turbo_rgb(t:f64)->(u8,u8,u8){
-    let x=t.clamp(0.0,1.0);
-    let r = 34.61 + x*(1172.33 + x*(-10793.56 + x*(33300.12 + x*(-38394.49 + x*14825.05))));
-    let g = 23.31 + x*(557.33  + x*(1225.33  + x*(-3574.96 + x*(4520.31  + x*(-1974.13)))));
-    let b = 27.2  + x*(321.15  + x*(1537.82  + x*(-4579.07 + x*(5496.05  + x*(-2163.56)))));
-    let to8 = |v:f64| -> u8 { v.round().clamp(0.0,255.0) as u8 };
+fn turbo_rgb(t: f64) -> (u8, u8, u8) {
+    let x = t.clamp(0.0, 1.0);
+    let r =
+        34.61 + x * (1172.33 + x * (-10793.56 + x * (33300.12 + x * (-38394.49 + x * 14825.05))));
+    let g = 23.31 + x * (557.33 + x * (1225.33 + x * (-3574.96 + x * (4520.31 + x * (-1974.13)))));
+    let b = 27.2 + x * (321.15 + x * (1537.82 + x * (-4579.07 + x * (5496.05 + x * (-2163.56)))));
+    let to8 = |v: f64| -> u8 { v.round().clamp(0.0, 255.0) as u8 };
     (to8(r), to8(g), to8(b))
+}
+
+fn draw_time_label(buf: &mut [u8], w: usize, h: usize, text: &str) {
+    let char_w = 5;
+    let char_h = 7;
+    let spacing = 1;
+    let width = text.chars().count() * (char_w + spacing) - spacing;
+    let x0 = 5usize;
+    let y0 = 5usize;
+    fill_rect(
+        buf,
+        w,
+        h,
+        x0.saturating_sub(2),
+        y0.saturating_sub(2),
+        x0 + width + 1,
+        y0 + char_h + 1,
+        [255, 255, 255],
+    );
+    draw_text(buf, w, h, x0, y0, text, [0, 0, 0]);
+}
+
+fn fill_rect(
+    buf: &mut [u8],
+    w: usize,
+    h: usize,
+    x0: usize,
+    y0: usize,
+    x1: usize,
+    y1: usize,
+    color: [u8; 3],
+) {
+    for y in y0..=y1 {
+        for x in x0..=x1 {
+            set_px(buf, w, h, x, y, color);
+        }
+    }
+}
+
+fn draw_text(
+    buf: &mut [u8],
+    w: usize,
+    h: usize,
+    mut x: usize,
+    y: usize,
+    text: &str,
+    color: [u8; 3],
+) {
+    for ch in text.chars() {
+        x += draw_char(buf, w, h, x, y, ch, color) + 1;
+    }
+}
+
+fn draw_char(
+    buf: &mut [u8],
+    w: usize,
+    h: usize,
+    x: usize,
+    y: usize,
+    ch: char,
+    color: [u8; 3],
+) -> usize {
+    let glyph: [u8; 7] = match ch {
+        '0' => [
+            0b01110, 0b10001, 0b10011, 0b10101, 0b11001, 0b10001, 0b01110,
+        ],
+        '1' => [
+            0b00100, 0b01100, 0b00100, 0b00100, 0b00100, 0b00100, 0b01110,
+        ],
+        '2' => [
+            0b01110, 0b10001, 0b00001, 0b00010, 0b00100, 0b01000, 0b11111,
+        ],
+        '3' => [
+            0b11110, 0b00001, 0b00001, 0b01110, 0b00001, 0b00001, 0b11110,
+        ],
+        '4' => [
+            0b10010, 0b10010, 0b10010, 0b11111, 0b00010, 0b00010, 0b00010,
+        ],
+        '5' => [
+            0b11111, 0b10000, 0b10000, 0b11110, 0b00001, 0b00001, 0b11110,
+        ],
+        '6' => [
+            0b01110, 0b10000, 0b10000, 0b11110, 0b10001, 0b10001, 0b01110,
+        ],
+        '7' => [
+            0b11111, 0b00001, 0b00010, 0b00100, 0b01000, 0b01000, 0b01000,
+        ],
+        '8' => [
+            0b01110, 0b10001, 0b10001, 0b01110, 0b10001, 0b10001, 0b01110,
+        ],
+        '9' => [
+            0b01110, 0b10001, 0b10001, 0b01111, 0b00001, 0b00001, 0b01110,
+        ],
+        '.' => [
+            0b00000, 0b00000, 0b00000, 0b00000, 0b00000, 0b01100, 0b01100,
+        ],
+        '=' => [
+            0b00000, 0b00000, 0b11111, 0b00000, 0b11111, 0b00000, 0b00000,
+        ],
+        't' | 'T' => [
+            0b01110, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100,
+        ],
+        _ => [0; 7],
+    };
+    for (j, row) in glyph.iter().enumerate() {
+        for i in 0..5 {
+            if (row >> (4 - i)) & 1 == 1 {
+                set_px(buf, w, h, x + i, y + j, color);
+            }
+        }
+    }
+    5
 }

--- a/convec/src/sim.rs
+++ b/convec/src/sim.rs
@@ -77,7 +77,7 @@ pub fn run(cfg: Config) -> Result<RunStats> {
 
     let mut writer = FrameWriter::new(cfg.output.clone(), nx, ny)?;
     if writer.cfg.enable {
-        writer.write_frame(&q, 0)?;
+        writer.write_frame(&q, 0.0)?;
     }
 
     let mut rhs = vec![0.0; nx * ny];
@@ -100,7 +100,7 @@ pub fn run(cfg: Config) -> Result<RunStats> {
             q[k] = (1.0 / 3.0) * q[k] + (2.0 / 3.0) * (q2[k] + dt * rhs[k]);
         }
 
-        writer.maybe_write(&q, n)?;
+        writer.maybe_write(&q, n, n as f64 * dt)?;
     }
 
     let cell = dx * dy;
@@ -133,7 +133,12 @@ pub fn run(cfg: Config) -> Result<RunStats> {
     };
     println!("# results");
     println!("min={:.6e} max={:.6e}", stats.qmin, stats.qmax);
-    println!("mass0={:.6e} mass1={:.6e} mass_err={:.6e}", stats.mass0, stats.mass1, stats.mass1 - stats.mass0);
+    println!(
+        "mass0={:.6e} mass1={:.6e} mass_err={:.6e}",
+        stats.mass0,
+        stats.mass1,
+        stats.mass1 - stats.mass0
+    );
     println!("L2 = {:.6e}", stats.l2);
     Ok(stats)
 }


### PR DESCRIPTION
## Summary
- overlay simulation time and enhance axes/grid rendering
- document advection schemes and time integrator in `convec`
- mention the convec solver in the repository README

## Testing
- `cd convec && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b62087483228f25953ee26e593d