### PR TITLE
Add upwind and TVD advection schemes

### DIFF
--- a/convec/README.md
+++ b/convec/README.md
@@ -6,7 +6,7 @@ This program solves the two-dimensional passive scalar advection equation
 \frac{\partial q}{\partial t} + u\frac{\partial q}{\partial x} + v\frac{\partial q}{\partial y} = 0
 ```
 
-with a solid body rotation velocity field. Two finite-difference schemes are
+with a solid body rotation velocity field. Several finite-difference schemes are
 available:
 
 * **Centered8** – eighth-order central derivative
@@ -16,6 +16,8 @@ available:
   ```
 
 * **WENO5** – fifth-order weighted essentially non-oscillatory scheme
+* **Upwind1** – first-order upwind difference
+* **TVD-Minmod**, **TVD-VanLeer** – second-order TVD schemes with flux limiters
 
   ```math
   \omega_k = \frac{\alpha_k}{\sum_{m=0}^2 \alpha_m},\qquad \alpha_k = \frac{d_k}{(\varepsilon+\beta_k)^2}
@@ -39,7 +41,7 @@ time overlaid in the corner for easier inspection.
 cargo run --release -- --config config.yaml
 ```
 
-Switch scheme by editing `scheme.type` (centered8 / weno5). Frames go to `output.dir`.
+Switch scheme by editing `scheme.type` (centered8 / weno5 / upwind1 / tvd_minmod / tvd_van_leer). Frames go to `output.dir`.
 
 ## Make video
 ```bash

--- a/convec/src/config.rs
+++ b/convec/src/config.rs
@@ -14,15 +14,22 @@ pub struct Config {
 
 impl Config {
     pub fn from_path<P: AsRef<Path>>(p: P) -> Result<Self> {
-        let s = fs::read_to_string(&p).with_context(|| format!("failed to read {}", p.as_ref().display()))?;
+        let s = fs::read_to_string(&p)
+            .with_context(|| format!("failed to read {}", p.as_ref().display()))?;
         let cfg: Config = serde_yaml::from_str(&s).with_context(|| "YAML parse error")?;
         Ok(cfg)
     }
     pub fn summary(&self) -> String {
         format!(
             "scheme={:?}, N=({},{}) CFL={} ROT={} out_dir={} stride={} fmt={:?}",
-            self.scheme.r#type, self.simulation.nx, self.simulation.ny, self.simulation.cfl,
-            self.simulation.rotations, self.output.dir, self.output.stride, self.output.format
+            self.scheme.r#type,
+            self.simulation.nx,
+            self.simulation.ny,
+            self.simulation.cfl,
+            self.simulation.rotations,
+            self.output.dir,
+            self.output.stride,
+            self.output.format
         )
     }
 }
@@ -42,7 +49,11 @@ pub struct SimulationCfg {
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum VelocityCfg {
-    SolidRotation { omega: f64, center_x: f64, center_y: f64 },
+    SolidRotation {
+        omega: f64,
+        center_x: f64,
+        center_y: f64,
+    },
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -55,7 +66,11 @@ pub enum InitialConditionCfg {
         slot_width: f64,
         slot_length: f64,
     },
-    Disk { center_x: f64, center_y: f64, radius: f64 },
+    Disk {
+        center_x: f64,
+        center_y: f64,
+        radius: f64,
+    },
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -69,6 +84,9 @@ pub struct SchemeCfg {
 pub enum SchemeType {
     Centered8,
     Weno5,
+    Upwind1,
+    TvdMinmod,
+    TvdVanLeer,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -102,12 +120,21 @@ pub enum ScaleCfg {
 
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
-pub enum OutFmt { Png, Ppm }
+pub enum OutFmt {
+    Png,
+    Ppm,
+}
 
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
-pub enum Interp { Nearest, Bilinear }
+pub enum Interp {
+    Nearest,
+    Bilinear,
+}
 
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
-pub enum Colormap { Gray, Turbo }
+pub enum Colormap {
+    Gray,
+    Turbo,
+}

--- a/convec/src/schemes/mod.rs
+++ b/convec/src/schemes/mod.rs
@@ -1,8 +1,22 @@
 pub trait Scheme {
-    fn rhs(&self, q:&[f64], u:&[f64], v:&[f64], dx:f64, dy:f64, nx:usize, ny:usize, out:&mut [f64]);
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    );
 }
 
 pub mod centered8;
+pub mod tvd;
+pub mod upwind1;
 pub mod weno5;
 pub use centered8::Centered8;
+pub use tvd::{TvdMinmod, TvdVanLeer};
+pub use upwind1::Upwind1;
 pub use weno5::Weno5Js;

--- a/convec/src/schemes/tvd.rs
+++ b/convec/src/schemes/tvd.rs
@@ -1,0 +1,124 @@
+use crate::schemes::Scheme;
+use crate::utils::{idx, pid};
+
+fn limiter_minmod(r: f64) -> f64 {
+    r.max(0.0).min(1.0)
+}
+
+fn limiter_van_leer(r: f64) -> f64 {
+    if r <= 0.0 {
+        0.0
+    } else {
+        (r + r.abs()) / (1.0 + r.abs())
+    }
+}
+
+fn tvd_flux_faces_1d(q: &[f64], u: &[f64], limiter: fn(f64) -> f64) -> Vec<f64> {
+    let n = q.len();
+    let eps = 1e-12;
+    let mut fh = vec![0.0; n];
+    for i in 0..n {
+        let im1 = pid(i as isize - 1, n);
+        let ip1 = pid(i as isize + 1, n);
+        let ip2 = pid(i as isize + 2, n);
+        let dqf = q[ip1] - q[i];
+        let dqb = q[i] - q[im1];
+        let r = if dqf.abs() < eps { 0.0 } else { dqb / dqf };
+        let ql = q[i] + 0.5 * limiter(r) * dqf;
+        let dqf1 = q[ip2] - q[ip1];
+        let dqb1 = q[ip1] - q[i];
+        let r1 = if dqf1.abs() < eps { 0.0 } else { dqb1 / dqf1 };
+        let qr = q[ip1] - 0.5 * limiter(r1) * (q[ip1] - q[i]);
+        let u_face = 0.5 * (u[i] + u[ip1]);
+        fh[i] = if u_face >= 0.0 {
+            u_face * ql
+        } else {
+            u_face * qr
+        };
+    }
+    fh
+}
+
+fn tvd_rhs(
+    q: &[f64],
+    u: &[f64],
+    v: &[f64],
+    dx: f64,
+    dy: f64,
+    nx: usize,
+    ny: usize,
+    out: &mut [f64],
+    limiter: fn(f64) -> f64,
+) {
+    let mut dfx = vec![0.0; nx * ny];
+    for j in 0..ny {
+        let mut qrow = vec![0.0; nx];
+        let mut urow = vec![0.0; nx];
+        for i in 0..nx {
+            let k = idx(i, j, nx);
+            qrow[i] = q[k];
+            urow[i] = u[k];
+        }
+        let fh = tvd_flux_faces_1d(&qrow, &urow, limiter);
+        for i in 0..nx {
+            let im = pid(i as isize - 1, nx);
+            dfx[idx(i, j, nx)] = (fh[i] - fh[im]) / dx;
+        }
+    }
+    let mut dfy = vec![0.0; nx * ny];
+    for i in 0..nx {
+        let mut qcol = vec![0.0; ny];
+        let mut vcol = vec![0.0; ny];
+        for j in 0..ny {
+            let k = idx(i, j, nx);
+            qcol[j] = q[k];
+            vcol[j] = v[k];
+        }
+        let gh = tvd_flux_faces_1d(&qcol, &vcol, limiter);
+        for j in 0..ny {
+            let jm = pid(j as isize - 1, ny);
+            dfy[idx(i, j, nx)] = (gh[j] - gh[jm]) / dy;
+        }
+    }
+    for k in 0..nx * ny {
+        out[k] = -(dfx[k] + dfy[k]);
+    }
+}
+
+/// minmod リミッターを用いたTVDスキーム。
+pub struct TvdMinmod;
+
+impl Scheme for TvdMinmod {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
+        tvd_rhs(q, u, v, dx, dy, nx, ny, out, limiter_minmod);
+    }
+}
+
+/// van Leer リミッターを用いたTVDスキーム。
+pub struct TvdVanLeer;
+
+impl Scheme for TvdVanLeer {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
+        tvd_rhs(q, u, v, dx, dy, nx, ny, out, limiter_van_leer);
+    }
+}

--- a/convec/src/schemes/upwind1.rs
+++ b/convec/src/schemes/upwind1.rs
@@ -1,0 +1,40 @@
+use crate::schemes::Scheme;
+use crate::utils::{idx, pid};
+
+/// 一次精度の風上差分スキーム。
+pub struct Upwind1;
+
+impl Scheme for Upwind1 {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
+        for j in 0..ny {
+            for i in 0..nx {
+                let k = idx(i, j, nx);
+                let im = pid(i as isize - 1, nx);
+                let ip = pid(i as isize + 1, nx);
+                let jm = pid(j as isize - 1, ny);
+                let jp = pid(j as isize + 1, ny);
+                let dqx = if u[k] >= 0.0 {
+                    (q[k] - q[idx(im, j, nx)]) / dx
+                } else {
+                    (q[idx(ip, j, nx)] - q[k]) / dx
+                };
+                let dqy = if v[k] >= 0.0 {
+                    (q[k] - q[idx(i, jm, nx)]) / dy
+                } else {
+                    (q[idx(i, jp, nx)] - q[k]) / dy
+                };
+                out[k] = -(u[k] * dqx + v[k] * dqy);
+            }
+        }
+    }
+}

--- a/convec/src/sim.rs
+++ b/convec/src/sim.rs
@@ -1,6 +1,6 @@
 use crate::config::{Config, SchemeType, VelocityCfg};
 use crate::render::FrameWriter;
-use crate::schemes::{Centered8, Scheme, Weno5Js};
+use crate::schemes::{Centered8, Scheme, TvdMinmod, TvdVanLeer, Upwind1, Weno5Js};
 use crate::shapes::init_field;
 use crate::utils::idx;
 use anyhow::Result;
@@ -73,6 +73,9 @@ pub fn run(cfg: Config) -> Result<RunStats> {
     let scheme_box: Box<dyn Scheme> = match cfg.scheme.r#type {
         SchemeType::Centered8 => Box::new(Centered8),
         SchemeType::Weno5 => Box::new(Weno5Js),
+        SchemeType::Upwind1 => Box::new(Upwind1),
+        SchemeType::TvdMinmod => Box::new(TvdMinmod),
+        SchemeType::TvdVanLeer => Box::new(TvdVanLeer),
     };
 
     let mut writer = FrameWriter::new(cfg.output.clone(), nx, ny)?;

--- a/convec/tests/schemes.rs
+++ b/convec/tests/schemes.rs
@@ -20,3 +20,21 @@ fn weno5_l2_below_threshold() {
     let l2 = run_and_get_l2("tests/weno5.yaml");
     assert!(l2 < 0.15, "L2 norm too large: {}", l2);
 }
+
+#[test]
+fn upwind1_l2_below_threshold() {
+    let l2 = run_and_get_l2("tests/upwind1.yaml");
+    assert!(l2 < 0.6, "L2 norm too large: {}", l2);
+}
+
+#[test]
+fn tvd_minmod_l2_below_threshold() {
+    let l2 = run_and_get_l2("tests/tvd_minmod.yaml");
+    assert!(l2 < 0.3, "L2 norm too large: {}", l2);
+}
+
+#[test]
+fn tvd_vanleer_l2_below_threshold() {
+    let l2 = run_and_get_l2("tests/tvd_vanleer.yaml");
+    assert!(l2 < 0.25, "L2 norm too large: {}", l2);
+}

--- a/convec/tests/tvd_minmod.yaml
+++ b/convec/tests/tvd_minmod.yaml
@@ -1,0 +1,45 @@
+simulation:
+  nx: 32
+  ny: 32
+  lx: 1.0
+  ly: 1.0
+  cfl: 0.40
+  rotations: 1
+  velocity:
+    type: solid_rotation
+    omega: 6.283185307179586
+    center_x: 0.5
+    center_y: 0.5
+
+initial_condition:
+  type: zalesak
+  center_x: 0.5
+  center_y: 0.75
+  radius: 0.18
+  slot_width: 0.06
+  slot_length: 0.26
+
+scheme:
+  type: tvd_minmod
+
+output:
+  enable: false
+  dir: frames
+  prefix: test
+  format: png
+  stride: 1
+  start_index: 0
+  scale:
+    mode: fixed
+    min: 0.0
+    max: 1.0
+  flip_y: true
+  out_w: 1000
+  out_h: 1000
+  interp: bilinear
+  grid: false
+  grid_step: 8
+  grid_thick: 1
+  axes: false
+  colormap: turbo
+  colorbar: false

--- a/convec/tests/tvd_vanleer.yaml
+++ b/convec/tests/tvd_vanleer.yaml
@@ -1,0 +1,45 @@
+simulation:
+  nx: 32
+  ny: 32
+  lx: 1.0
+  ly: 1.0
+  cfl: 0.40
+  rotations: 1
+  velocity:
+    type: solid_rotation
+    omega: 6.283185307179586
+    center_x: 0.5
+    center_y: 0.5
+
+initial_condition:
+  type: zalesak
+  center_x: 0.5
+  center_y: 0.75
+  radius: 0.18
+  slot_width: 0.06
+  slot_length: 0.26
+
+scheme:
+  type: tvd_van_leer
+
+output:
+  enable: false
+  dir: frames
+  prefix: test
+  format: png
+  stride: 1
+  start_index: 0
+  scale:
+    mode: fixed
+    min: 0.0
+    max: 1.0
+  flip_y: true
+  out_w: 1000
+  out_h: 1000
+  interp: bilinear
+  grid: false
+  grid_step: 8
+  grid_thick: 1
+  axes: false
+  colormap: turbo
+  colorbar: false

--- a/convec/tests/upwind1.yaml
+++ b/convec/tests/upwind1.yaml
@@ -1,0 +1,45 @@
+simulation:
+  nx: 32
+  ny: 32
+  lx: 1.0
+  ly: 1.0
+  cfl: 0.40
+  rotations: 1
+  velocity:
+    type: solid_rotation
+    omega: 6.283185307179586
+    center_x: 0.5
+    center_y: 0.5
+
+initial_condition:
+  type: zalesak
+  center_x: 0.5
+  center_y: 0.75
+  radius: 0.18
+  slot_width: 0.06
+  slot_length: 0.26
+
+scheme:
+  type: upwind1
+
+output:
+  enable: false
+  dir: frames
+  prefix: test
+  format: png
+  stride: 1
+  start_index: 0
+  scale:
+    mode: fixed
+    min: 0.0
+    max: 1.0
+  flip_y: true
+  out_w: 1000
+  out_h: 1000
+  interp: bilinear
+  grid: false
+  grid_step: 8
+  grid_thick: 1
+  axes: false
+  colormap: turbo
+  colorbar: false


### PR DESCRIPTION
## Summary
- implement first-order upwind advection scheme
- add TVD schemes with Minmod and Van Leer limiters
- cover new schemes with regression tests and documentation

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ab1553a1c88322a0bb026e919a62ce