### PR TITLE
Add SSPRK(5,4) integrator selectable via config

### DIFF
--- a/convec/src/config.rs
+++ b/convec/src/config.rs
@@ -21,8 +21,9 @@ impl Config {
     }
     pub fn summary(&self) -> String {
         format!(
-            "scheme={:?}, N=({},{}) CFL={} ROT={} out_dir={} stride={} fmt={:?}",
+            "scheme={:?}, time_int={:?}, N=({},{}) CFL={} ROT={} out_dir={} stride={} fmt={:?}",
             self.scheme.r#type,
+            self.simulation.time_integrator,
             self.simulation.nx,
             self.simulation.ny,
             self.simulation.cfl,
@@ -44,6 +45,8 @@ pub struct SimulationCfg {
     pub cfl: f64,
     pub rotations: usize,
     pub velocity: VelocityCfg,
+    #[serde(default)]
+    pub time_integrator: TimeIntegrator,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -87,6 +90,24 @@ pub enum SchemeType {
     Upwind1,
     TvdMinmod,
     TvdVanLeer,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+/// Strong-stability-preserving Runge–Kutta time integrators.
+/// - `SspRk3`: 3-stage 3rd-order scheme of Shu & Osher (1989).
+/// - `SspRk54`: 5-stage 4th-order scheme of Spiteri & Ruuth (2002).
+pub enum TimeIntegrator {
+    /// SSPRK(3,3)
+    SspRk3,
+    /// SSPRK(5,4)
+    SspRk54,
+}
+
+impl Default for TimeIntegrator {
+    fn default() -> Self {
+        TimeIntegrator::SspRk3
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/convec/src/sim.rs
+++ b/convec/src/sim.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, SchemeType, VelocityCfg};
+use crate::config::{Config, SchemeType, TimeIntegrator, VelocityCfg};
 use crate::render::FrameWriter;
 use crate::schemes::{Centered8, Scheme, TvdMinmod, TvdVanLeer, Upwind1, Weno5Js};
 use crate::shapes::init_field;
@@ -15,10 +15,16 @@ pub struct RunStats {
 }
 
 /// 2 次元スカラー移流方程式を解くメインループ。
-/// 時間積分には Shu & Osher による 3 段の TVD Runge–Kutta 法\[1\]を用いる。
+/// 時間積分には強安定性保存 (SSP) Runge–Kutta 法を用い，設定により
+/// 次のいずれかを選択できる：
+/// - 3 段 3 次の SSPRK(3,3) 法\[1\]
+/// - 5 段 4 次の SSPRK(5,4) 法\[2\]
 ///
 /// [1] C.-W. Shu and S. Osher, "Efficient implementation of essentially non-oscillatory
 /// shock-capturing schemes, II", *Journal of Computational Physics*, 83(1), 32-78, 1989.
+/// [2] R. J. Spiteri and S. J. Ruuth, "A new class of optimal high-order
+/// strong-stability-preserving time discretization methods", *SIAM Journal on
+/// Numerical Analysis*, 40(2), 469-491, 2002.
 pub fn run(cfg: Config) -> Result<RunStats> {
     let nx = cfg.simulation.nx;
     let ny = cfg.simulation.ny;
@@ -86,21 +92,65 @@ pub fn run(cfg: Config) -> Result<RunStats> {
     let mut rhs = vec![0.0; nx * ny];
     let mut q1 = vec![0.0; nx * ny];
     let mut q2 = vec![0.0; nx * ny];
+    let mut q3 = vec![0.0; nx * ny];
+    let mut q4 = vec![0.0; nx * ny];
+
+    let integrator = cfg.simulation.time_integrator;
 
     for n in 1..=steps {
-        scheme_box.rhs(&q, &u, &v, dx, dy, nx, ny, &mut rhs);
-        for k in 0..nx * ny {
-            q1[k] = q[k] + dt * rhs[k];
-        }
+        match integrator {
+            TimeIntegrator::SspRk3 => {
+                // SSPRK(3,3) [1]:
+                // q^(1) = q^n + dt * L(q^n)
+                scheme_box.rhs(&q, &u, &v, dx, dy, nx, ny, &mut rhs);
+                for k in 0..nx * ny {
+                    q1[k] = q[k] + dt * rhs[k];
+                }
 
-        scheme_box.rhs(&q1, &u, &v, dx, dy, nx, ny, &mut rhs);
-        for k in 0..nx * ny {
-            q2[k] = 0.75 * q[k] + 0.25 * (q1[k] + dt * rhs[k]);
-        }
+                // q^(2) = 3/4 q^n + 1/4 (q^(1) + dt * L(q^(1)))
+                scheme_box.rhs(&q1, &u, &v, dx, dy, nx, ny, &mut rhs);
+                for k in 0..nx * ny {
+                    q2[k] = 0.75 * q[k] + 0.25 * (q1[k] + dt * rhs[k]);
+                }
 
-        scheme_box.rhs(&q2, &u, &v, dx, dy, nx, ny, &mut rhs);
-        for k in 0..nx * ny {
-            q[k] = (1.0 / 3.0) * q[k] + (2.0 / 3.0) * (q2[k] + dt * rhs[k]);
+                // q^{n+1} = 1/3 q^n + 2/3 (q^(2) + dt * L(q^(2)))
+                scheme_box.rhs(&q2, &u, &v, dx, dy, nx, ny, &mut rhs);
+                for k in 0..nx * ny {
+                    q[k] = (1.0 / 3.0) * q[k] + (2.0 / 3.0) * (q2[k] + dt * rhs[k]);
+                }
+            }
+            TimeIntegrator::SspRk54 => {
+                // SSPRK(5,4) [2]:
+                // q^(1) = q^n + dt * L(q^n)
+                scheme_box.rhs(&q, &u, &v, dx, dy, nx, ny, &mut rhs);
+                for k in 0..nx * ny {
+                    q1[k] = q[k] + dt * rhs[k];
+                }
+
+                // q^(2) = q^(1) + dt * L(q^(1))
+                scheme_box.rhs(&q1, &u, &v, dx, dy, nx, ny, &mut rhs);
+                for k in 0..nx * ny {
+                    q2[k] = q1[k] + dt * rhs[k];
+                }
+
+                // q^(3) = 3/4 q^n + 1/4 (q^(2) + dt * L(q^(2)))
+                scheme_box.rhs(&q2, &u, &v, dx, dy, nx, ny, &mut rhs);
+                for k in 0..nx * ny {
+                    q3[k] = 0.75 * q[k] + 0.25 * (q2[k] + dt * rhs[k]);
+                }
+
+                // q^(4) = q^(3) + dt * L(q^(3))
+                scheme_box.rhs(&q3, &u, &v, dx, dy, nx, ny, &mut rhs);
+                for k in 0..nx * ny {
+                    q4[k] = q3[k] + dt * rhs[k];
+                }
+
+                // q^{n+1} = 1/3 q^n + 2/3 (q^(4) + dt * L(q^(4)))
+                scheme_box.rhs(&q4, &u, &v, dx, dy, nx, ny, &mut rhs);
+                for k in 0..nx * ny {
+                    q[k] = (1.0 / 3.0) * q[k] + (2.0 / 3.0) * (q4[k] + dt * rhs[k]);
+                }
+            }
         }
 
         writer.maybe_write(&q, n, n as f64 * dt)?;

--- a/convec/tests/centered8_ssprk54.yaml
+++ b/convec/tests/centered8_ssprk54.yaml
@@ -1,0 +1,48 @@
+# Example using the 5-stage 4th-order SSPRK(5,4) time integrator
+# Reference: R. J. Spiteri and S. J. Ruuth, SIAM J. Numer. Anal., 40(2), 469-491 (2002)
+simulation:
+  nx: 32
+  ny: 32
+  lx: 1.0
+  ly: 1.0
+  cfl: 0.40
+  rotations: 1
+  time_integrator: ssp_rk54
+  velocity:
+    type: solid_rotation
+    omega: 6.283185307179586
+    center_x: 0.5
+    center_y: 0.5
+
+initial_condition:
+  type: zalesak
+  center_x: 0.5
+  center_y: 0.75
+  radius: 0.18
+  slot_width: 0.06
+  slot_length: 0.26
+
+scheme:
+  type: centered8
+
+output:
+  enable: false
+  dir: frames
+  prefix: test
+  format: png
+  stride: 1
+  start_index: 0
+  scale:
+    mode: fixed
+    min: 0.0
+    max: 1.0
+  flip_y: true
+  out_w: 1000
+  out_h: 1000
+  interp: bilinear
+  grid: false
+  grid_step: 8
+  grid_thick: 1
+  axes: false
+  colormap: turbo
+  colorbar: false

--- a/convec/tests/schemes.rs
+++ b/convec/tests/schemes.rs
@@ -16,6 +16,14 @@ fn centered8_l2_below_threshold() {
 }
 
 #[test]
+/// Verify the 5-stage 4th-order SSPRK(5,4) scheme [Spiteri & Ruuth 2002]
+/// integrates the centered8 spatial discretization with acceptable error.
+fn centered8_ssprk54_l2_below_threshold() {
+    let l2 = run_and_get_l2("tests/centered8_ssprk54.yaml");
+    assert!(l2 < 0.35, "L2 norm too large: {}", l2);
+}
+
+#[test]
 fn weno5_l2_below_threshold() {
     let l2 = run_and_get_l2("tests/weno5.yaml");
     assert!(l2 < 0.15, "L2 norm too large: {}", l2);


### PR DESCRIPTION
## Summary
- implement SSPRK(5,4) time integration scheme
- allow choosing time integrator via `time_integrator` in simulation config
- document SSPRK schemes with formulas and literature references
- test switching to SSPRK(5,4) through YAML example

## Testing
- `cd convec && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab18be5578832292cfd68f53f4f136