### PR TITLE
Add CIP-CSL2 and MP5 schemes

### DIFF
--- a/convec/src/config.rs
+++ b/convec/src/config.rs
@@ -91,6 +91,9 @@ pub enum SchemeType {
     Cip,
     CipCsl,
     CipB,
+    CipCsl2,
+    CipCsl2Mh,
+    Mp5,
     TvdMinmod,
     TvdVanLeer,
 }

--- a/convec/src/schemes/cip.rs
+++ b/convec/src/schemes/cip.rs
@@ -9,7 +9,37 @@ fn cip_face(ql: f64, qr: f64, dql: f64, dqr: f64, dx: f64) -> f64 {
     ql + dql * x + a * x * x + b * x * x * x
 }
 
-fn flux_x(q: &[f64], dqx: &[f64], u: &[f64], dx: f64, nx: usize, j: usize, limiter: bool) -> Vec<f64> {
+/// Limit left and right slopes so that the cubic Hermite profile remains monotonic.
+fn monotonic_slopes(ql: f64, qr: f64, mut dl: f64, mut dr: f64, dx: f64) -> (f64, f64) {
+    let delta = (qr - ql) / dx;
+    if delta == 0.0 {
+        return (0.0, 0.0);
+    }
+    let mut r = dl / delta;
+    let mut s = dr / delta;
+    if r * s <= 0.0 {
+        return (0.0, 0.0);
+    }
+    let sum = r + s;
+    if sum > 3.0 {
+        let k = 3.0 / sum;
+        r *= k;
+        s *= k;
+    }
+    dl = r * delta;
+    dr = s * delta;
+    (dl, dr)
+}
+
+fn flux_x(
+    q: &[f64],
+    dqx: &[f64],
+    u: &[f64],
+    dx: f64,
+    nx: usize,
+    j: usize,
+    limiter: bool,
+) -> Vec<f64> {
     let mut f = vec![0.0; nx];
     for i in 0..nx {
         let ip = pid(i as isize + 1, nx);
@@ -36,7 +66,16 @@ fn flux_x(q: &[f64], dqx: &[f64], u: &[f64], dx: f64, nx: usize, j: usize, limit
     f
 }
 
-fn flux_y(q: &[f64], dqy: &[f64], v: &[f64], dy: f64, nx: usize, ny: usize, i: usize, limiter: bool) -> Vec<f64> {
+fn flux_y(
+    q: &[f64],
+    dqy: &[f64],
+    v: &[f64],
+    dy: f64,
+    nx: usize,
+    ny: usize,
+    i: usize,
+    limiter: bool,
+) -> Vec<f64> {
     let mut g = vec![0.0; ny];
     for j in 0..ny {
         let jp = pid(j as isize + 1, ny);
@@ -89,14 +128,64 @@ fn derivative_y(q: &[f64], dy: f64, nx: usize, ny: usize) -> Vec<f64> {
     dqy
 }
 
+/// Fourth-order central difference of the x-derivative.
+fn derivative_x4(q: &[f64], dx: f64, nx: usize, ny: usize) -> Vec<f64> {
+    let mut dqx = vec![0.0; nx * ny];
+    for j in 0..ny {
+        for i in 0..nx {
+            let im2 = pid(i as isize - 2, nx);
+            let im1 = pid(i as isize - 1, nx);
+            let ip1 = pid(i as isize + 1, nx);
+            let ip2 = pid(i as isize + 2, nx);
+            let k = idx(i, j, nx);
+            dqx[k] = (q[idx(im2, j, nx)] - 8.0 * q[idx(im1, j, nx)] + 8.0 * q[idx(ip1, j, nx)]
+                - q[idx(ip2, j, nx)])
+                / (12.0 * dx);
+        }
+    }
+    dqx
+}
+
+/// Fourth-order central difference of the y-derivative.
+fn derivative_y4(q: &[f64], dy: f64, nx: usize, ny: usize) -> Vec<f64> {
+    let mut dqy = vec![0.0; nx * ny];
+    for i in 0..nx {
+        for j in 0..ny {
+            let jm2 = pid(j as isize - 2, ny);
+            let jm1 = pid(j as isize - 1, ny);
+            let jp1 = pid(j as isize + 1, ny);
+            let jp2 = pid(j as isize + 2, ny);
+            let k = idx(i, j, nx);
+            dqy[k] = (q[idx(i, jm2, nx)] - 8.0 * q[idx(i, jm1, nx)] + 8.0 * q[idx(i, jp1, nx)]
+                - q[idx(i, jp2, nx)])
+                / (12.0 * dy);
+        }
+    }
+    dqy
+}
+
 /// Cubic interpolated propagation scheme.
 pub struct Cip;
 /// Conservative CIP scheme preserving cell averages.
 pub struct CipCsl;
 /// Bounded CIP scheme with a min–max limiter.
 pub struct CipB;
+/// Higher-order conservative CIP-CSL2 scheme.
+pub struct CipCsl2;
+/// CIP-CSL2 scheme with monotonicity-constrained Hermite interpolation.
+pub struct CipCsl2Mh;
 
-fn cip_rhs(q: &[f64], u: &[f64], v: &[f64], dx: f64, dy: f64, nx: usize, ny: usize, limiter: bool, out: &mut [f64]) {
+fn cip_rhs(
+    q: &[f64],
+    u: &[f64],
+    v: &[f64],
+    dx: f64,
+    dy: f64,
+    nx: usize,
+    ny: usize,
+    limiter: bool,
+    out: &mut [f64],
+) {
     let dqx = derivative_x(q, dx, nx, ny);
     let dqy = derivative_y(q, dy, nx, ny);
     let mut dfx = vec![0.0; nx * ny];
@@ -120,21 +209,150 @@ fn cip_rhs(q: &[f64], u: &[f64], v: &[f64], dx: f64, dy: f64, nx: usize, ny: usi
     }
 }
 
+fn cip_csl2_rhs(
+    q: &[f64],
+    u: &[f64],
+    v: &[f64],
+    dx: f64,
+    dy: f64,
+    nx: usize,
+    ny: usize,
+    monotonic: bool,
+    out: &mut [f64],
+) {
+    let dqx = derivative_x4(q, dx, nx, ny);
+    let dqy = derivative_y4(q, dy, nx, ny);
+    let mut dfx = vec![0.0; nx * ny];
+    for j in 0..ny {
+        let mut f = vec![0.0; nx];
+        for i in 0..nx {
+            let ip = pid(i as isize + 1, nx);
+            let idx0 = idx(i, j, nx);
+            let idxp = idx(ip, j, nx);
+            let u_face = 0.5 * (u[idx0] + u[idxp]);
+            let (ql, qr, mut dql, mut dqr) = if u_face >= 0.0 {
+                (q[idx0], q[idxp], dqx[idx0], dqx[idxp])
+            } else {
+                (q[idxp], q[idx0], dqx[idxp], dqx[idx0])
+            };
+            if monotonic {
+                let (dl, dr) = monotonic_slopes(ql, qr, dql, dqr, dx);
+                dql = dl;
+                dqr = dr;
+            }
+            f[i] = u_face * cip_face(ql, qr, dql, dqr, dx);
+        }
+        for i in 0..nx {
+            let im = pid(i as isize - 1, nx);
+            dfx[idx(i, j, nx)] = (f[i] - f[im]) / dx;
+        }
+    }
+    let mut dfy = vec![0.0; nx * ny];
+    for i in 0..nx {
+        let mut g = vec![0.0; ny];
+        for j in 0..ny {
+            let jp = pid(j as isize + 1, ny);
+            let idx0 = idx(i, j, nx);
+            let idxp = idx(i, jp, nx);
+            let v_face = 0.5 * (v[idx0] + v[idxp]);
+            let (ql, qr, mut dql, mut dqr) = if v_face >= 0.0 {
+                (q[idx0], q[idxp], dqy[idx0], dqy[idxp])
+            } else {
+                (q[idxp], q[idx0], dqy[idxp], dqy[idx0])
+            };
+            if monotonic {
+                let (dl, dr) = monotonic_slopes(ql, qr, dql, dqr, dy);
+                dql = dl;
+                dqr = dr;
+            }
+            g[j] = v_face * cip_face(ql, qr, dql, dqr, dy);
+        }
+        for j in 0..ny {
+            let jm = pid(j as isize - 1, ny);
+            dfy[idx(i, j, nx)] = (g[j] - g[jm]) / dy;
+        }
+    }
+    for k in 0..nx * ny {
+        out[k] = -(dfx[k] + dfy[k]);
+    }
+}
+
 impl Scheme for Cip {
-    fn rhs(&self, q: &[f64], u: &[f64], v: &[f64], dx: f64, dy: f64, nx: usize, ny: usize, out: &mut [f64]) {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
         cip_rhs(q, u, v, dx, dy, nx, ny, false, out);
     }
 }
 
 impl Scheme for CipCsl {
-    fn rhs(&self, q: &[f64], u: &[f64], v: &[f64], dx: f64, dy: f64, nx: usize, ny: usize, out: &mut [f64]) {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
         cip_rhs(q, u, v, dx, dy, nx, ny, false, out);
     }
 }
 
 impl Scheme for CipB {
-    fn rhs(&self, q: &[f64], u: &[f64], v: &[f64], dx: f64, dy: f64, nx: usize, ny: usize, out: &mut [f64]) {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
         cip_rhs(q, u, v, dx, dy, nx, ny, true, out);
     }
 }
 
+impl Scheme for CipCsl2 {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
+        cip_csl2_rhs(q, u, v, dx, dy, nx, ny, false, out);
+    }
+}
+
+impl Scheme for CipCsl2Mh {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
+        cip_csl2_rhs(q, u, v, dx, dy, nx, ny, true, out);
+    }
+}

--- a/convec/src/schemes/mod.rs
+++ b/convec/src/schemes/mod.rs
@@ -14,11 +14,13 @@ pub trait Scheme {
 
 pub mod centered8;
 pub mod cip;
+pub mod mp5;
 pub mod tvd;
 pub mod upwind1;
 pub mod weno5;
 pub use centered8::Centered8;
-pub use cip::{Cip, CipB, CipCsl};
+pub use cip::{Cip, CipB, CipCsl, CipCsl2, CipCsl2Mh};
+pub use mp5::Mp5;
 pub use tvd::{TvdMinmod, TvdVanLeer};
 pub use upwind1::Upwind1;
 pub use weno5::Weno5Js;

--- a/convec/src/schemes/mp5.rs
+++ b/convec/src/schemes/mp5.rs
@@ -1,0 +1,115 @@
+use crate::schemes::Scheme;
+use crate::utils::{idx, pid};
+
+/// Monotonicity preserving fifth-order scheme (MP5).
+pub struct Mp5;
+
+fn mp5_face_pos(q: &[f64], i: usize, n: usize) -> f64 {
+    let im2 = q[pid(i as isize - 2, n)];
+    let im1 = q[pid(i as isize - 1, n)];
+    let i0 = q[i];
+    let ip1 = q[pid(i as isize + 1, n)];
+    let ip2 = q[pid(i as isize + 2, n)];
+    let mut qf = (2.0 * im2 - 13.0 * im1 + 47.0 * i0 + 27.0 * ip1 - 3.0 * ip2) / 60.0;
+    let min = im1.min(i0.min(ip1));
+    let max = im1.max(i0.max(ip1));
+    if qf < min {
+        qf = min;
+    } else if qf > max {
+        qf = max;
+    }
+    qf
+}
+
+fn mp5_face_neg(q: &[f64], i: usize, n: usize) -> f64 {
+    let ip2 = q[pid(i as isize + 2, n)];
+    let ip1 = q[pid(i as isize + 1, n)];
+    let i0 = q[i];
+    let im1 = q[pid(i as isize - 1, n)];
+    let im2 = q[pid(i as isize - 2, n)];
+    let mut qf = (2.0 * ip2 - 13.0 * ip1 + 47.0 * i0 + 27.0 * im1 - 3.0 * im2) / 60.0;
+    let min = im1.min(i0.min(ip1));
+    let max = im1.max(i0.max(ip1));
+    if qf < min {
+        qf = min;
+    } else if qf > max {
+        qf = max;
+    }
+    qf
+}
+
+fn flux_x(q: &[f64], u: &[f64], _dx: f64, nx: usize, j: usize) -> Vec<f64> {
+    let mut f = vec![0.0; nx];
+    let mut qq = vec![0.0; nx];
+    for i in 0..nx {
+        qq[i] = q[idx(i, j, nx)];
+    }
+    for i in 0..nx {
+        let ip = pid(i as isize + 1, nx);
+        let idx0 = idx(i, j, nx);
+        let idxp = idx(ip, j, nx);
+        let u_face = 0.5 * (u[idx0] + u[idxp]);
+        let qf = if u_face >= 0.0 {
+            mp5_face_pos(&qq, i, nx)
+        } else {
+            mp5_face_neg(&qq, ip, nx)
+        };
+        f[i] = u_face * qf;
+    }
+    f
+}
+
+fn flux_y(q: &[f64], v: &[f64], _dy: f64, nx: usize, ny: usize, i: usize) -> Vec<f64> {
+    let mut g = vec![0.0; ny];
+    let mut qq = vec![0.0; ny];
+    for j in 0..ny {
+        qq[j] = q[idx(i, j, nx)];
+    }
+    for j in 0..ny {
+        let jp = pid(j as isize + 1, ny);
+        let idx0 = idx(i, j, nx);
+        let idxp = idx(i, jp, nx);
+        let v_face = 0.5 * (v[idx0] + v[idxp]);
+        let qf = if v_face >= 0.0 {
+            mp5_face_pos(&qq, j, ny)
+        } else {
+            mp5_face_neg(&qq, jp, ny)
+        };
+        g[j] = v_face * qf;
+    }
+    g
+}
+
+impl Scheme for Mp5 {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
+        let mut dfx = vec![0.0; nx * ny];
+        for j in 0..ny {
+            let fx = flux_x(q, u, dx, nx, j);
+            for i in 0..nx {
+                let im = pid(i as isize - 1, nx);
+                dfx[idx(i, j, nx)] = (fx[i] - fx[im]) / dx;
+            }
+        }
+        let mut dfy = vec![0.0; nx * ny];
+        for i in 0..nx {
+            let fy = flux_y(q, v, dy, nx, ny, i);
+            for j in 0..ny {
+                let jm = pid(j as isize - 1, ny);
+                dfy[idx(i, j, nx)] = (fy[j] - fy[jm]) / dy;
+            }
+        }
+        for k in 0..nx * ny {
+            out[k] = -(dfx[k] + dfy[k]);
+        }
+    }
+}

--- a/convec/src/sim.rs
+++ b/convec/src/sim.rs
@@ -1,7 +1,8 @@
 use crate::config::{Config, SchemeType, TimeIntegrator, VelocityCfg};
 use crate::render::FrameWriter;
 use crate::schemes::{
-    Centered8, Cip, CipB, CipCsl, Scheme, TvdMinmod, TvdVanLeer, Upwind1, Weno5Js,
+    Centered8, Cip, CipB, CipCsl, CipCsl2, CipCsl2Mh, Mp5, Scheme, TvdMinmod, TvdVanLeer, Upwind1,
+    Weno5Js,
 };
 use crate::shapes::init_field;
 use crate::utils::idx;
@@ -85,6 +86,9 @@ pub fn run(cfg: Config) -> Result<RunStats> {
         SchemeType::Cip => Box::new(Cip),
         SchemeType::CipCsl => Box::new(CipCsl),
         SchemeType::CipB => Box::new(CipB),
+        SchemeType::CipCsl2 => Box::new(CipCsl2),
+        SchemeType::CipCsl2Mh => Box::new(CipCsl2Mh),
+        SchemeType::Mp5 => Box::new(Mp5),
         SchemeType::TvdMinmod => Box::new(TvdMinmod),
         SchemeType::TvdVanLeer => Box::new(TvdVanLeer),
     };

--- a/convec/tests/cip_csl2.yaml
+++ b/convec/tests/cip_csl2.yaml
@@ -1,0 +1,45 @@
+simulation:
+  nx: 32
+  ny: 32
+  lx: 1.0
+  ly: 1.0
+  cfl: 0.40
+  rotations: 1
+  velocity:
+    type: solid_rotation
+    omega: 6.283185307179586
+    center_x: 0.5
+    center_y: 0.5
+
+initial_condition:
+  type: zalesak
+  center_x: 0.5
+  center_y: 0.75
+  radius: 0.18
+  slot_width: 0.06
+  slot_length: 0.26
+
+scheme:
+  type: cip_csl2
+
+output:
+  enable: false
+  dir: frames
+  prefix: test
+  format: png
+  stride: 1
+  start_index: 0
+  scale:
+    mode: fixed
+    min: 0.0
+    max: 1.0
+  flip_y: true
+  out_w: 1000
+  out_h: 1000
+  interp: bilinear
+  grid: false
+  grid_step: 8
+  grid_thick: 1
+  axes: false
+  colormap: turbo
+  colorbar: false

--- a/convec/tests/cip_csl2_mh.yaml
+++ b/convec/tests/cip_csl2_mh.yaml
@@ -1,0 +1,45 @@
+simulation:
+  nx: 32
+  ny: 32
+  lx: 1.0
+  ly: 1.0
+  cfl: 0.40
+  rotations: 1
+  velocity:
+    type: solid_rotation
+    omega: 6.283185307179586
+    center_x: 0.5
+    center_y: 0.5
+
+initial_condition:
+  type: zalesak
+  center_x: 0.5
+  center_y: 0.75
+  radius: 0.18
+  slot_width: 0.06
+  slot_length: 0.26
+
+scheme:
+  type: cip_csl2_mh
+
+output:
+  enable: false
+  dir: frames
+  prefix: test
+  format: png
+  stride: 1
+  start_index: 0
+  scale:
+    mode: fixed
+    min: 0.0
+    max: 1.0
+  flip_y: true
+  out_w: 1000
+  out_h: 1000
+  interp: bilinear
+  grid: false
+  grid_step: 8
+  grid_thick: 1
+  axes: false
+  colormap: turbo
+  colorbar: false

--- a/convec/tests/mp5.yaml
+++ b/convec/tests/mp5.yaml
@@ -1,0 +1,45 @@
+simulation:
+  nx: 32
+  ny: 32
+  lx: 1.0
+  ly: 1.0
+  cfl: 0.40
+  rotations: 1
+  velocity:
+    type: solid_rotation
+    omega: 6.283185307179586
+    center_x: 0.5
+    center_y: 0.5
+
+initial_condition:
+  type: zalesak
+  center_x: 0.5
+  center_y: 0.75
+  radius: 0.18
+  slot_width: 0.06
+  slot_length: 0.26
+
+scheme:
+  type: mp5
+
+output:
+  enable: false
+  dir: frames
+  prefix: test
+  format: png
+  stride: 1
+  start_index: 0
+  scale:
+    mode: fixed
+    min: 0.0
+    max: 1.0
+  flip_y: true
+  out_w: 1000
+  out_h: 1000
+  interp: bilinear
+  grid: false
+  grid_step: 8
+  grid_thick: 1
+  axes: false
+  colormap: turbo
+  colorbar: false

--- a/convec/tests/schemes.rs
+++ b/convec/tests/schemes.rs
@@ -64,3 +64,21 @@ fn cip_b_l2_below_threshold() {
     let l2 = run_and_get_l2("tests/cip_b.yaml");
     assert!(l2 < 0.3, "L2 norm too large: {}", l2);
 }
+
+#[test]
+fn cip_csl2_l2_below_threshold() {
+    let l2 = run_and_get_l2("tests/cip_csl2.yaml");
+    assert!(l2 < 0.31, "L2 norm too large: {}", l2);
+}
+
+#[test]
+fn cip_csl2_mh_l2_below_threshold() {
+    let l2 = run_and_get_l2("tests/cip_csl2_mh.yaml");
+    assert!(l2 < 0.31, "L2 norm too large: {}", l2);
+}
+
+#[test]
+fn mp5_l2_below_threshold() {
+    let l2 = run_and_get_l2("tests/mp5.yaml");
+    assert!(l2 < 0.17, "L2 norm too large: {}", l2);
+}


### PR DESCRIPTION
## Summary
- add high-order CIP-CSL2 scheme with optional monotonic Hermite slopes
- implement monotonicity-preserving MP5 advection scheme
- wire new schemes into configuration and simulation with regression tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ab206c37f883229566ad53bfad410b