### PR TITLE
Add 10th- and 12th-order centered advection schemes

### DIFF
--- a/convec/README.md
+++ b/convec/README.md
@@ -10,6 +10,8 @@ with a solid body rotation velocity field. Several finite-difference schemes are
 available:
 
 * **Centered8** – eighth-order central derivative
+* **Centered10** – tenth-order central derivative
+* **Centered12** – twelfth-order central derivative
 
   ```math
   \frac{\partial f}{\partial x}\Big|_i \approx \frac{1}{280\Delta x}(-3 f_{i-4}+32 f_{i-3}-168 f_{i-2}+672 f_{i-1}-672 f_{i+1}+168 f_{i+2}-32 f_{i+3}+3 f_{i+4})
@@ -42,7 +44,7 @@ time overlaid in the corner for easier inspection.
 cargo run --release -- --config config.yaml
 ```
 
-Switch scheme by editing `scheme.type` (centered8 / weno5 / upwind1 / tvd_minmod / tvd_van_leer). Frames go to `output.dir`.
+Switch scheme by editing `scheme.type` (centered8 / centered10 / centered12 / weno5 / upwind1 / tvd_minmod / tvd_van_leer). Frames go to `output.dir`.
 
 ## Make video
 ```bash

--- a/convec/src/config.rs
+++ b/convec/src/config.rs
@@ -86,6 +86,8 @@ pub struct SchemeCfg {
 #[serde(rename_all = "snake_case")]
 pub enum SchemeType {
     Centered8,
+    Centered10,
+    Centered12,
     Weno5,
     Upwind1,
     Cip,

--- a/convec/src/schemes/centered10.rs
+++ b/convec/src/schemes/centered10.rs
@@ -1,0 +1,90 @@
+//! 10次精度の中心差分による移流項の離散化を行うスキーム。
+//! 係数は Fornberg による有限差分公式の一般化[1]に基づく。
+//!
+//! [1] B. Fornberg, "Generation of finite difference formulas on arbitrarily spaced grids",
+//! *Mathematics of Computation*, 51(184), 699-706, 1988.
+use crate::schemes::Scheme;
+use crate::utils::{idx, pid};
+
+pub struct Centered10;
+
+const C10: [f64; 11] = [
+    -1.0 / 1260.0,
+    5.0 / 504.0,
+    -5.0 / 84.0,
+    5.0 / 21.0,
+    -5.0 / 6.0,
+    0.0,
+    5.0 / 6.0,
+    -5.0 / 21.0,
+    5.0 / 84.0,
+    -5.0 / 504.0,
+    1.0 / 1260.0,
+];
+
+fn d1x(f: &[f64], nx: usize, ny: usize, dx: f64, out: &mut [f64]) {
+    for j in 0..ny {
+        for i in 0..nx {
+            let mut acc = 0.0;
+            for s in -5..=5 {
+                if s != 0 {
+                    let w = C10[(s + 5) as usize];
+                    let ii = pid(i as isize + s as isize, nx);
+                    acc += w * f[idx(ii, j, nx)];
+                }
+            }
+            out[idx(i, j, nx)] = acc / dx;
+        }
+    }
+}
+
+fn d1y(f: &[f64], nx: usize, ny: usize, dy: f64, out: &mut [f64]) {
+    for j in 0..ny {
+        for i in 0..nx {
+            let mut acc = 0.0;
+            for s in -5..=5 {
+                if s != 0 {
+                    let w = C10[(s + 5) as usize];
+                    let jj = pid(j as isize + s as isize, ny);
+                    acc += w * f[idx(i, jj, nx)];
+                }
+            }
+            out[idx(i, j, nx)] = acc / dy;
+        }
+    }
+}
+
+impl Scheme for Centered10 {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
+        let mut dqx = vec![0.0; nx * ny];
+        let mut dqy = vec![0.0; nx * ny];
+        d1x(q, nx, ny, dx, &mut dqx);
+        d1y(q, nx, ny, dy, &mut dqy);
+
+        let mut uq = vec![0.0; nx * ny];
+        let mut vq = vec![0.0; nx * ny];
+        for k in 0..nx * ny {
+            uq[k] = u[k] * q[k];
+            vq[k] = v[k] * q[k];
+        }
+
+        let mut dx_uq = vec![0.0; nx * ny];
+        let mut dy_vq = vec![0.0; nx * ny];
+        d1x(&uq, nx, ny, dx, &mut dx_uq);
+        d1y(&vq, nx, ny, dy, &mut dy_vq);
+
+        for k in 0..nx * ny {
+            out[k] = -0.5 * (u[k] * dqx[k] + dx_uq[k] + v[k] * dqy[k] + dy_vq[k]);
+        }
+    }
+}

--- a/convec/src/schemes/centered12.rs
+++ b/convec/src/schemes/centered12.rs
@@ -1,0 +1,92 @@
+//! 12次精度の中心差分による移流項の離散化を行うスキーム。
+//! 係数は Fornberg による有限差分公式の一般化[1]に基づく。
+//!
+//! [1] B. Fornberg, "Generation of finite difference formulas on arbitrarily spaced grids",
+//! *Mathematics of Computation*, 51(184), 699-706, 1988.
+use crate::schemes::Scheme;
+use crate::utils::{idx, pid};
+
+pub struct Centered12;
+
+const C12: [f64; 13] = [
+    1.0 / 5544.0,
+    -1.0 / 385.0,
+    1.0 / 56.0,
+    -5.0 / 63.0,
+    15.0 / 56.0,
+    -6.0 / 7.0,
+    0.0,
+    6.0 / 7.0,
+    -15.0 / 56.0,
+    5.0 / 63.0,
+    -1.0 / 56.0,
+    1.0 / 385.0,
+    -1.0 / 5544.0,
+];
+
+fn d1x(f: &[f64], nx: usize, ny: usize, dx: f64, out: &mut [f64]) {
+    for j in 0..ny {
+        for i in 0..nx {
+            let mut acc = 0.0;
+            for s in -6..=6 {
+                if s != 0 {
+                    let w = C12[(s + 6) as usize];
+                    let ii = pid(i as isize + s as isize, nx);
+                    acc += w * f[idx(ii, j, nx)];
+                }
+            }
+            out[idx(i, j, nx)] = acc / dx;
+        }
+    }
+}
+
+fn d1y(f: &[f64], nx: usize, ny: usize, dy: f64, out: &mut [f64]) {
+    for j in 0..ny {
+        for i in 0..nx {
+            let mut acc = 0.0;
+            for s in -6..=6 {
+                if s != 0 {
+                    let w = C12[(s + 6) as usize];
+                    let jj = pid(j as isize + s as isize, ny);
+                    acc += w * f[idx(i, jj, nx)];
+                }
+            }
+            out[idx(i, j, nx)] = acc / dy;
+        }
+    }
+}
+
+impl Scheme for Centered12 {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
+        let mut dqx = vec![0.0; nx * ny];
+        let mut dqy = vec![0.0; nx * ny];
+        d1x(q, nx, ny, dx, &mut dqx);
+        d1y(q, nx, ny, dy, &mut dqy);
+
+        let mut uq = vec![0.0; nx * ny];
+        let mut vq = vec![0.0; nx * ny];
+        for k in 0..nx * ny {
+            uq[k] = u[k] * q[k];
+            vq[k] = v[k] * q[k];
+        }
+
+        let mut dx_uq = vec![0.0; nx * ny];
+        let mut dy_vq = vec![0.0; nx * ny];
+        d1x(&uq, nx, ny, dx, &mut dx_uq);
+        d1y(&vq, nx, ny, dy, &mut dy_vq);
+
+        for k in 0..nx * ny {
+            out[k] = -0.5 * (u[k] * dqx[k] + dx_uq[k] + v[k] * dqy[k] + dy_vq[k]);
+        }
+    }
+}

--- a/convec/src/schemes/mod.rs
+++ b/convec/src/schemes/mod.rs
@@ -12,6 +12,8 @@ pub trait Scheme {
     );
 }
 
+pub mod centered10;
+pub mod centered12;
 pub mod centered8;
 pub mod cip;
 pub mod mp5;
@@ -19,6 +21,8 @@ pub mod tvd;
 pub mod upwind1;
 pub mod weno5;
 pub use centered8::Centered8;
+pub use centered10::Centered10;
+pub use centered12::Centered12;
 pub use cip::{Cip, CipB, CipCsl, CipCsl2, CipCsl2Mh};
 pub use mp5::Mp5;
 pub use tvd::{TvdMinmod, TvdVanLeer};

--- a/convec/src/sim.rs
+++ b/convec/src/sim.rs
@@ -1,8 +1,8 @@
 use crate::config::{Config, SchemeType, TimeIntegrator, VelocityCfg};
 use crate::render::FrameWriter;
 use crate::schemes::{
-    Centered8, Cip, CipB, CipCsl, CipCsl2, CipCsl2Mh, Mp5, Scheme, TvdMinmod, TvdVanLeer, Upwind1,
-    Weno5Js,
+    Centered8, Centered10, Centered12, Cip, CipB, CipCsl, CipCsl2, CipCsl2Mh, Mp5, Scheme,
+    TvdMinmod, TvdVanLeer, Upwind1, Weno5Js,
 };
 use crate::shapes::init_field;
 use crate::utils::idx;
@@ -81,6 +81,8 @@ pub fn run(cfg: Config) -> Result<RunStats> {
 
     let scheme_box: Box<dyn Scheme> = match cfg.scheme.r#type {
         SchemeType::Centered8 => Box::new(Centered8),
+        SchemeType::Centered10 => Box::new(Centered10),
+        SchemeType::Centered12 => Box::new(Centered12),
         SchemeType::Weno5 => Box::new(Weno5Js),
         SchemeType::Upwind1 => Box::new(Upwind1),
         SchemeType::Cip => Box::new(Cip),

--- a/convec/tests/centered10.yaml
+++ b/convec/tests/centered10.yaml
@@ -1,0 +1,45 @@
+simulation:
+  nx: 32
+  ny: 32
+  lx: 1.0
+  ly: 1.0
+  cfl: 0.40
+  rotations: 1
+  velocity:
+    type: solid_rotation
+    omega: 6.283185307179586
+    center_x: 0.5
+    center_y: 0.5
+
+initial_condition:
+  type: zalesak
+  center_x: 0.5
+  center_y: 0.75
+  radius: 0.18
+  slot_width: 0.06
+  slot_length: 0.26
+
+scheme:
+  type: centered10
+
+output:
+  enable: false
+  dir: frames
+  prefix: test
+  format: png
+  stride: 1
+  start_index: 0
+  scale:
+    mode: fixed
+    min: 0.0
+    max: 1.0
+  flip_y: true
+  out_w: 1000
+  out_h: 1000
+  interp: bilinear
+  grid: false
+  grid_step: 8
+  grid_thick: 1
+  axes: false
+  colormap: turbo
+  colorbar: false

--- a/convec/tests/centered12.yaml
+++ b/convec/tests/centered12.yaml
@@ -1,0 +1,45 @@
+simulation:
+  nx: 32
+  ny: 32
+  lx: 1.0
+  ly: 1.0
+  cfl: 0.40
+  rotations: 1
+  velocity:
+    type: solid_rotation
+    omega: 6.283185307179586
+    center_x: 0.5
+    center_y: 0.5
+
+initial_condition:
+  type: zalesak
+  center_x: 0.5
+  center_y: 0.75
+  radius: 0.18
+  slot_width: 0.06
+  slot_length: 0.26
+
+scheme:
+  type: centered12
+
+output:
+  enable: false
+  dir: frames
+  prefix: test
+  format: png
+  stride: 1
+  start_index: 0
+  scale:
+    mode: fixed
+    min: 0.0
+    max: 1.0
+  flip_y: true
+  out_w: 1000
+  out_h: 1000
+  interp: bilinear
+  grid: false
+  grid_step: 8
+  grid_thick: 1
+  axes: false
+  colormap: turbo
+  colorbar: false

--- a/convec/tests/schemes.rs
+++ b/convec/tests/schemes.rs
@@ -16,6 +16,18 @@ fn centered8_l2_below_threshold() {
 }
 
 #[test]
+fn centered10_l2_below_threshold() {
+    let l2 = run_and_get_l2("tests/centered10.yaml");
+    assert!(l2 < 0.15, "L2 norm too large: {}", l2);
+}
+
+#[test]
+fn centered12_l2_below_threshold() {
+    let l2 = run_and_get_l2("tests/centered12.yaml");
+    assert!(l2 < 0.15, "L2 norm too large: {}", l2);
+}
+
+#[test]
 /// Verify the 5-stage 4th-order SSPRK(5,4) scheme [Spiteri & Ruuth 2002]
 /// integrates the centered8 spatial discretization with acceptable error.
 fn centered8_ssprk54_l2_below_threshold() {


### PR DESCRIPTION
## Summary
- implement high-order centered10 and centered12 advection schemes
- expose new schemes in configuration and simulation dispatch
- document and test centered10 and centered12 options

## Testing
- `cargo test`
- `cargo run -- --config tests/centered10.yaml`
- `cargo run -- --config tests/centered12.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68ac55f1a2b883228a8024651676b9d0