### PR TITLE
Add jet colormap and disable grid by default

### DIFF
--- a/convec/README.md
+++ b/convec/README.md
@@ -37,7 +37,9 @@ q^{n+1} &= \tfrac{1}{3} q^n + \tfrac{2}{3}\big(q^{(2)} + \Delta t\,L(q^{(2)})\bi
 ```
 
 Frames are saved with a colour bar, thicker axes, and the current simulation
-time overlaid in the corner for easier inspection.
+time overlaid in the corner for easier inspection. The grid overlay is
+disabled by default, and the colour map defaults to `jet` (also supporting
+`turbo` and `gray`).
 
 ## Build & Run
 ```bash

--- a/convec/config.yaml
+++ b/convec/config.yaml
@@ -37,9 +37,9 @@ output:
   out_w: 1000
   out_h: 1000
   interp: bilinear
-  grid: true
+  grid: false
   grid_step: 8
   grid_thick: 2
   axes: true
-  colormap: turbo
+  colormap: jet
   colorbar: true

--- a/convec/src/config.rs
+++ b/convec/src/config.rs
@@ -132,11 +132,16 @@ pub struct OutputCfg {
     pub out_w: Option<usize>,
     pub out_h: Option<usize>,
     pub interp: Interp,
+    #[serde(default)]
     pub grid: bool,
+    #[serde(default = "default_grid_step")]
     pub grid_step: usize,
+    #[serde(default = "default_grid_thick")]
     pub grid_thick: usize,
     pub axes: bool,
+    #[serde(default)]
     pub colormap: Colormap,
+    #[serde(default)]
     pub colorbar: bool,
 }
 
@@ -166,4 +171,19 @@ pub enum Interp {
 pub enum Colormap {
     Gray,
     Turbo,
+    Jet,
+}
+
+impl Default for Colormap {
+    fn default() -> Self {
+        Colormap::Jet
+    }
+}
+
+fn default_grid_step() -> usize {
+    8
+}
+
+fn default_grid_thick() -> usize {
+    1
 }

--- a/convec/src/render.rs
+++ b/convec/src/render.rs
@@ -105,6 +105,7 @@ impl FrameWriter {
                         (c, c, c)
                     }
                     Colormap::Turbo => turbo_rgb(norm),
+                    Colormap::Jet => jet_rgb(norm),
                 };
                 let yy = if self.cfg.flip_y { h - 1 - py } else { py };
                 let p = (yy * w + px) * 3;
@@ -246,6 +247,7 @@ fn draw_colorbar(buf: &mut [u8], w: usize, h: usize, cmap: Colormap) {
                 (c, c, c)
             }
             Colormap::Turbo => turbo_rgb(t),
+            Colormap::Jet => jet_rgb(t),
         };
         for x in x0..w {
             let p = (y * w + x) * 3;
@@ -262,6 +264,15 @@ fn turbo_rgb(t: f64) -> (u8, u8, u8) {
     let g = 23.31 + x * (557.33 + x * (1225.33 + x * (-3574.96 + x * (4520.31 + x * (-1974.13)))));
     let b = 27.2 + x * (321.15 + x * (1537.82 + x * (-4579.07 + x * (5496.05 + x * (-2163.56)))));
     let to8 = |v: f64| -> u8 { v.round().clamp(0.0, 255.0) as u8 };
+    (to8(r), to8(g), to8(b))
+}
+
+fn jet_rgb(t: f64) -> (u8, u8, u8) {
+    let x = t.clamp(0.0, 1.0);
+    let r = (1.5 - (4.0 * x - 3.0).abs()).clamp(0.0, 1.0);
+    let g = (1.5 - (4.0 * x - 2.0).abs()).clamp(0.0, 1.0);
+    let b = (1.5 - (4.0 * x - 1.0).abs()).clamp(0.0, 1.0);
+    let to8 = |v: f64| -> u8 { (v * 255.0).round().clamp(0.0, 255.0) as u8 };
     (to8(r), to8(g), to8(b))
 }
 


### PR DESCRIPTION
## Summary
- default grid overlay disabled
- add jet colormap and make it default
- update docs and example config

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac59c03f808322ba7b6043626055a7