### PR TITLE
Add high-order centered advection scheme

### DIFF
--- a/convec/README.md
+++ b/convec/README.md
@@ -23,6 +23,7 @@ available:
 
 * **Centered10** – tenth-order central derivative
 * **Centered12** – twelfth-order central derivative
+* **Centered14** – fourteenth-order central derivative
 * **WENO5** – fifth-order weighted essentially non-oscillatory scheme
 * **WENO5-Z** – improved fifth-order WENO using Z-type weights
 * **WENO7-Z** – seventh-order WENO with Z-type weights

--- a/convec/src/config.rs
+++ b/convec/src/config.rs
@@ -106,6 +106,7 @@ pub enum SchemeType {
     Centered8,
     Centered10,
     Centered12,
+    Centered14,
     Weno5,
     Weno5Z,
     Weno7Z,

--- a/convec/src/schemes/centered14.rs
+++ b/convec/src/schemes/centered14.rs
@@ -1,0 +1,96 @@
+//! 14次精度の中心差分による移流項の離散化を行うスキーム。
+//! 係数は Fornberg による有限差分公式の一般化[1]に基づく。
+//!
+//! [1] B. Fornberg, "Generation of finite difference formulas on arbitrarily spaced grids",
+//! *Mathematics of Computation*, 51(184), 699-706, 1988.
+use crate::schemes::Scheme;
+use crate::utils::{idx, pid};
+
+pub struct Centered14;
+
+// Coefficients for the 14th-order centered finite-difference approximation of the first derivative.
+// Generated via SymPy's `finite_diff_weights` following Fornberg's algorithm.
+const C14: [f64; 15] = [
+    -1.0 / 24024.0,
+    7.0 / 10296.0,
+    -7.0 / 1320.0,
+    7.0 / 264.0,
+    -7.0 / 72.0,
+    7.0 / 24.0,
+    -7.0 / 8.0,
+    0.0,
+    7.0 / 8.0,
+    -7.0 / 24.0,
+    7.0 / 72.0,
+    -7.0 / 264.0,
+    7.0 / 1320.0,
+    -7.0 / 10296.0,
+    1.0 / 24024.0,
+];
+
+fn d1x(f: &[f64], nx: usize, ny: usize, dx: f64, out: &mut [f64]) {
+    for j in 0..ny {
+        for i in 0..nx {
+            let mut acc = 0.0;
+            for s in -7..=7 {
+                if s != 0 {
+                    let w = C14[(s + 7) as usize];
+                    let ii = pid(i as isize + s as isize, nx);
+                    acc += w * f[idx(ii, j, nx)];
+                }
+            }
+            out[idx(i, j, nx)] = acc / dx;
+        }
+    }
+}
+
+fn d1y(f: &[f64], nx: usize, ny: usize, dy: f64, out: &mut [f64]) {
+    for j in 0..ny {
+        for i in 0..nx {
+            let mut acc = 0.0;
+            for s in -7..=7 {
+                if s != 0 {
+                    let w = C14[(s + 7) as usize];
+                    let jj = pid(j as isize + s as isize, ny);
+                    acc += w * f[idx(i, jj, nx)];
+                }
+            }
+            out[idx(i, j, nx)] = acc / dy;
+        }
+    }
+}
+
+impl Scheme for Centered14 {
+    fn rhs(
+        &self,
+        q: &[f64],
+        u: &[f64],
+        v: &[f64],
+        dx: f64,
+        dy: f64,
+        nx: usize,
+        ny: usize,
+        out: &mut [f64],
+    ) {
+        let mut dqx = vec![0.0; nx * ny];
+        let mut dqy = vec![0.0; nx * ny];
+        d1x(q, nx, ny, dx, &mut dqx);
+        d1y(q, nx, ny, dy, &mut dqy);
+
+        let mut uq = vec![0.0; nx * ny];
+        let mut vq = vec![0.0; nx * ny];
+        for k in 0..nx * ny {
+            uq[k] = u[k] * q[k];
+            vq[k] = v[k] * q[k];
+        }
+
+        let mut dx_uq = vec![0.0; nx * ny];
+        let mut dy_vq = vec![0.0; nx * ny];
+        d1x(&uq, nx, ny, dx, &mut dx_uq);
+        d1y(&vq, nx, ny, dy, &mut dy_vq);
+
+        for k in 0..nx * ny {
+            out[k] = -0.5 * (u[k] * dqx[k] + dx_uq[k] + v[k] * dqy[k] + dy_vq[k]);
+        }
+    }
+}

--- a/convec/src/schemes/mod.rs
+++ b/convec/src/schemes/mod.rs
@@ -14,6 +14,7 @@ pub trait Scheme {
 
 pub mod centered10;
 pub mod centered12;
+pub mod centered14;
 pub mod centered6;
 pub mod centered8;
 pub mod cip;
@@ -28,6 +29,7 @@ pub use centered6::Centered6;
 pub use centered8::Centered8;
 pub use centered10::Centered10;
 pub use centered12::Centered12;
+pub use centered14::Centered14;
 pub use cip::{Cip, CipB, CipCsl, CipCsl2, CipCsl2Mh};
 pub use mp5::Mp5;
 pub use tvd::{TvdMinmod, TvdVanLeer};

--- a/convec/src/sim.rs
+++ b/convec/src/sim.rs
@@ -3,8 +3,8 @@
 use crate::config::{Config, SchemeType, TimeIntegrator, VelocityCfg};
 use crate::render::FrameWriter;
 use crate::schemes::{
-    Centered6, Centered8, Centered10, Centered12, Cip, CipB, CipCsl, CipCsl2, CipCsl2Mh, Mp5,
-    Scheme, TvdMinmod, TvdVanLeer, Upwind1, Upwind3x3, Weno5Js, Weno5Z, Weno7Z,
+    Centered6, Centered8, Centered10, Centered12, Centered14, Cip, CipB, CipCsl, CipCsl2,
+    CipCsl2Mh, Mp5, Scheme, TvdMinmod, TvdVanLeer, Upwind1, Upwind3x3, Weno5Js, Weno5Z, Weno7Z,
 };
 use crate::shapes::init_field;
 use crate::utils::idx;
@@ -91,6 +91,7 @@ pub fn run(cfg: Config) -> Result<RunStats> {
         SchemeType::Centered8 => Box::new(Centered8),
         SchemeType::Centered10 => Box::new(Centered10),
         SchemeType::Centered12 => Box::new(Centered12),
+        SchemeType::Centered14 => Box::new(Centered14),
         SchemeType::Weno5 => Box::new(Weno5Js),
         SchemeType::Weno5Z => Box::new(Weno5Z),
         SchemeType::Weno7Z => Box::new(Weno7Z),

--- a/convec/tests/centered14.yaml
+++ b/convec/tests/centered14.yaml
@@ -1,0 +1,45 @@
+simulation:
+  nx: 32
+  ny: 32
+  lx: 1.0
+  ly: 1.0
+  cfl: 0.40
+  rotations: 1
+  velocity:
+    type: solid_rotation
+    omega: 6.283185307179586
+    center_x: 0.5
+    center_y: 0.5
+
+initial_condition:
+  type: zalesak
+  center_x: 0.5
+  center_y: 0.75
+  radius: 0.18
+  slot_width: 0.06
+  slot_length: 0.26
+
+scheme:
+  type: centered14
+
+output:
+  enable: false
+  dir: frames
+  prefix: test
+  format: png
+  stride: 1
+  start_index: 0
+  scale:
+    mode: fixed
+    min: 0.0
+    max: 1.0
+  flip_y: true
+  out_w: 1000
+  out_h: 1000
+  interp: bilinear
+  grid: false
+  grid_step: 8
+  grid_thick: 1
+  axes: false
+  colormap: turbo
+  colorbar: false

--- a/convec/tests/schemes.rs
+++ b/convec/tests/schemes.rs
@@ -69,6 +69,12 @@ fn centered12_l2_below_threshold() {
 }
 
 #[test]
+fn centered14_l2_below_threshold() {
+    let l2 = run_and_get_l2("tests/centered14.yaml");
+    assert!(l2 < 0.15, "L2 norm too large: {}", l2);
+}
+
+#[test]
 /// Verify the 5-stage 4th-order SSPRK(5,4) scheme [Spiteri & Ruuth 2002]
 /// integrates the centered8 spatial discretization with acceptable error.
 fn centered8_ssprk54_l2_below_threshold() {


### PR DESCRIPTION
## Summary
- add 14th-order centered finite-difference advection scheme based on Fornberg's coefficients
- expose new scheme via configuration, tests, and documentation
- include regression test for centered14 scheme

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ac73d62d7c832282cbc327e4227812