### PR TITLE
docs: add scheme comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,40 @@ The scripts `chemkin_to_md.py` and `chemkin_to_graph.py` help document CHEMKIN
 reaction mechanisms. The former renders the `REACTIONS` block in a Markdown
 list, while the latter builds a Graphviz graph of species connectivity. PNG
 output from `chemkin_to_graph.py` requires the Graphviz `dot` executable.
+## Comparison of spatial discretisation schemes
+
+The repository includes a variety of one-dimensional advection schemes.  The table
+summarises each method's formal accuracy in smooth regions, a ballpark estimate of
+per-step cost, and typical uses.  Cost is measured relative to a first-order
+upwind method.
+
+| Scheme | Order | Relative cost | Typical use |
+|-------|------|---------------|-------------|
+| upwind1 | 1 | 1× | cheapest but very diffusive; quick sweeps |
+| tvd_minmod | 2 | 1.5× | extremely robust TVD limiter; crude shock capturing |
+| tvd_van_leer | 2 | 1.5× | smoother TVD limiter; moderate diffusion |
+| upwind3x3 | 3 | 2× | compact 3×3 upwind stencil in 2-D; cheap and stable |
+| centered6 | 6 | 2× | low dispersion for smooth waves; no shock control |
+| centered8 | 8 | 2.5× | as above with wider stencil |
+| centered10 | 10 | 3× | very accurate in periodic problems |
+| centered12 | 12 | 3.5× | high-order wave propagation |
+| centered14 | 14 | 4× | niche, resolves fine spectra; fragile near shocks |
+| cip | 3 | 3× | cubic profile; needs stored gradients |
+| cip_csl | 4 | 3.5× | conservative CIP using cubic spline |
+| cip_b | 4 | 4× | B-spline flavour; smoother at extra cost |
+| cip_csl2 | 4 | 4× | extended conservative scheme |
+| cip_csl2_mh | 4 | 5× | multi-moment hybrid; most accurate CIP variant |
+| mp5 | 5 | 5× | monotonicity preserving; good general-purpose shock capturing |
+| weno5 | 5 | 5× | classic WENO-JS; balances cost and accuracy |
+| weno5_z | 5 | 5× | WENO-Z weights reduce dissipation |
+| weno7_z | 7 | 7× | higher order shock capturing |
+| weno9_z | 9 | 9× | very accurate but expensive; research-grade DNS |
+
+### Rough ranking
+
+- **Highest fidelity near discontinuities:** WENO9_Z > WENO7_Z > MP5 ≈ WENO5_Z > WENO5 > CIP_CSL2_MH > CIP_CSL2 > CIP_B ≈ CIP_CSL > CIP > TVD_van_leer > TVD_minmod > upwind3x3 > upwind1 > centered schemes.
+- **Best for smooth periodic problems:** centered14 ≥ centered12 ≥ centered10 ≥ centered8 ≥ centered6.
+- **Cheapest per grid point:** upwind1 < tvd_minmod ≈ tvd_van_leer < upwind3x3 < centered6.
+
+These rankings are intentionally loose but give a flavour of trade-offs among
+accuracy, robustness and cost.


### PR DESCRIPTION
## Summary
- add table comparing centered, upwind, TVD, CIP, WENO and MP5 discretization schemes
- note rough rankings for accuracy, cost and appropriate problem classes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac7e2d9df08322932588a4da605d90